### PR TITLE
Fix [:listener, :start] telemetry event

### DIFF
--- a/lib/thousand_island/listener.ex
+++ b/lib/thousand_island/listener.ex
@@ -28,16 +28,12 @@ defmodule ThousandIsland.Listener do
       }) do
     case transport_module.listen(port, transport_opts) do
       {:ok, listener_socket} ->
-        :telemetry.execute(
-          [:listener, :start],
-          %{
-            port: transport_module.listen_port(listener_socket) |> elem(1)
-          },
-          %{
-            transport_module: transport_module,
-            transport_opts: transport_opts
-          }
-        )
+        {:ok, port} = transport_module.listen_port(listener_socket)
+
+        :telemetry.execute([:listener, :start], %{port: port}, %{
+          transport_module: transport_module,
+          transport_opts: transport_opts
+        })
 
         {:ok, %{listener_socket: listener_socket, transport_module: transport_module}}
 

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -82,12 +82,17 @@ defmodule ThousandIsland.ServerTest do
     test "it should emit telemetry events as expected" do
       {:ok, collector_pid} = start_collector()
       {:ok, server_pid, _} = start_handler(Echo)
+      {:ok, port} = ThousandIsland.local_port(server_pid)
 
       ThousandIsland.stop(server_pid)
 
       events = ThousandIsland.TelemetryCollector.get_events(collector_pid)
       assert length(events) == 2
-      assert {[:listener, :start], %{}, _} = Enum.at(events, 0)
+
+      assert {[:listener, :start], %{port: ^port},
+              %{transport_module: ThousandIsland.Transports.TCP, transport_opts: []}} =
+               Enum.at(events, 0)
+
       assert {[:listener, :shutdown], %{}, _} = Enum.at(events, 1)
     end
   end

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -116,13 +116,17 @@ defmodule ThousandIsland.SocketTest do
 
         events = ThousandIsland.TelemetryCollector.get_events(collector_pid)
         assert length(events) == 4
-        assert {[:socket, :handshake], %{}, _} = Enum.at(events, 0)
-        assert {[:socket, :recv], %{result: {:ok, "HELLO"}}, _} = Enum.at(events, 1)
-        assert {[:socket, :send], %{data: "HELLO", result: :ok}, _} = Enum.at(events, 2)
+        assert {[:socket, :handshake], %{}, %{connection_id: connection_id}} = Enum.at(events, 0)
+
+        assert {[:socket, :recv], %{result: {:ok, "HELLO"}}, %{connection_id: ^connection_id}} =
+                 Enum.at(events, 1)
+
+        assert {[:socket, :send], %{data: "HELLO", result: :ok}, %{connection_id: ^connection_id}} =
+                 Enum.at(events, 2)
 
         assert {[:socket, :close],
                 %{octets_recv: _, octets_sent: _, packets_recv: _, packets_sent: _},
-                %{}} = Enum.at(events, 3)
+                %{connection_id: ^connection_id}} = Enum.at(events, 3)
       end
     end
   end)


### PR DESCRIPTION
The `listener_start` telemetry event was failing because of the `{:ok, port}` tuple response from `transport_module.listen_port(listener_socket) `

- fixed by just grabbing second element from tuple (the actual port number) 