### PR TITLE
Refactor ThousandIsland.Handler response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ defmodule Echo do
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
     ThousandIsland.Socket.send(socket, data)
-    {:ok, :continue, state}
+    {:continue, state}
   end
 end
 

--- a/examples/daytime.ex
+++ b/examples/daytime.ex
@@ -11,6 +11,6 @@ defmodule Daytime do
   def handle_connection(socket, state) do
     time = DateTime.utc_now() |> to_string()
     ThousandIsland.Socket.send(socket, time)
-    {:ok, :close, state}
+    {:close, state}
   end
 end

--- a/examples/echo.ex
+++ b/examples/echo.ex
@@ -10,6 +10,6 @@ defmodule Echo do
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
     ThousandIsland.Socket.send(socket, data)
-    {:ok, :continue, state}
+    {:continue, state}
   end
 end

--- a/examples/http_hello_world.ex
+++ b/examples/http_hello_world.ex
@@ -10,6 +10,6 @@ defmodule HTTPHelloWorld do
   @impl ThousandIsland.Handler
   def handle_data(_data, socket, state) do
     ThousandIsland.Socket.send(socket, "HTTP/1.0 200 OK\r\n\r\nHello, World")
-    {:ok, :close, state}
+    {:close, state}
   end
 end

--- a/examples/messenger.ex
+++ b/examples/messenger.ex
@@ -15,13 +15,13 @@ defmodule Messenger do
   def handle_connection(socket, state) do
     %{address: remote_address} = ThousandIsland.Socket.peer_info(socket)
     IO.puts("#{inspect(self())} received connection from #{remote_address}")
-    {:ok, :continue, state}
+    {:continue, state}
   end
 
   @impl ThousandIsland.Handler
   def handle_data(msg, _socket, state) do
     IO.puts("Received #{msg}")
-    {:ok, :continue, state}
+    {:continue, state}
   end
 
   @impl GenServer

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -12,12 +12,12 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_connection(_socket, state) do
-        {:ok, :continue, state}
+        {:continue, state}
       end
 
       @impl ThousandIsland.Handler
       def handle_data("ping", _socket, state) do
-        {:ok, :close, state}
+        {:close, state}
       end
 
       @impl ThousandIsland.Handler
@@ -49,11 +49,11 @@ defmodule ThousandIsland.HandlerTest do
       @impl ThousandIsland.Handler
       def handle_connection(socket, state) do
         ThousandIsland.Socket.send(socket, "HELLO")
-        {:ok, :continue, state}
+        {:continue, state}
       end
     end
 
-    test "it should keep the connection open if {:ok, :continue, state} is returned" do
+    test "it should keep the connection open if {:continue, state} is returned" do
       {:ok, port} = start_handler(HandleConnection.HelloWorld)
       {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
       assert :gen_tcp.recv(client, 0) == {:ok, 'HELLO'}
@@ -65,11 +65,11 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_connection(_socket, state) do
-        {:ok, :close, state}
+        {:close, state}
       end
     end
 
-    test "it should close the connection if {:ok, :close, state} is returned" do
+    test "it should close the connection if {:close, state} is returned" do
       {:ok, port} = start_handler(HandleConnection.Closer)
       {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
       assert :gen_tcp.recv(client, 0) == {:error, :closed}
@@ -143,11 +143,11 @@ defmodule ThousandIsland.HandlerTest do
       @impl ThousandIsland.Handler
       def handle_data("ping", socket, state) do
         ThousandIsland.Socket.send(socket, "HELLO")
-        {:ok, :continue, state}
+        {:continue, state}
       end
     end
 
-    test "it should keep the connection open if {:ok, :continue, state} is returned" do
+    test "it should keep the connection open if {:continue, state} is returned" do
       {:ok, port} = start_handler(HandleData.HelloWorld)
       {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
       :gen_tcp.send(client, "ping")
@@ -160,11 +160,11 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_data("ping", _socket, state) do
-        {:ok, :close, state}
+        {:close, state}
       end
     end
 
-    test "it should close the connection if {:ok, :close, state} is returned" do
+    test "it should close the connection if {:close, state} is returned" do
       {:ok, port} = start_handler(HandleData.Closer)
       {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
       :gen_tcp.send(client, "ping")
@@ -242,7 +242,7 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_connection(_socket, state) do
-        {:ok, :continue, state, 50}
+        {:continue, state, 50}
       end
 
       @impl ThousandIsland.Handler
@@ -272,7 +272,7 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_data("ping", _socket, state) do
-        {:ok, :continue, state, 50}
+        {:continue, state, 50}
       end
 
       @impl ThousandIsland.Handler
@@ -328,7 +328,7 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_data(_data, _socket, state) do
-        {:ok, :close, state}
+        {:close, state}
       end
     end
 
@@ -388,7 +388,7 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_connection(_socket, state) do
-        {:ok, :close, state}
+        {:close, state}
       end
     end
 

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -9,7 +9,7 @@ defmodule ThousandIsland.ServerTest do
     def handle_connection(socket, state) do
       {:ok, data} = ThousandIsland.Socket.recv(socket, 0)
       ThousandIsland.Socket.send(socket, data)
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 
@@ -19,7 +19,7 @@ defmodule ThousandIsland.ServerTest do
     @impl ThousandIsland.Handler
     def handle_shutdown(socket, state) do
       ThousandIsland.Socket.send(socket, "GOODBYE")
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -33,7 +33,7 @@ defmodule ThousandIsland.SocketTest do
     def handle_connection(socket, state) do
       {:ok, data} = ThousandIsland.Socket.recv(socket, 0)
       ThousandIsland.Socket.send(socket, data)
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 
@@ -44,7 +44,7 @@ defmodule ThousandIsland.SocketTest do
     def handle_connection(socket, state) do
       ThousandIsland.Socket.sendfile(socket, Path.join(__DIR__, "../support/sendfile"), 0, 6)
       ThousandIsland.Socket.sendfile(socket, Path.join(__DIR__, "../support/sendfile"), 1, 3)
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 
@@ -53,7 +53,7 @@ defmodule ThousandIsland.SocketTest do
 
     @impl ThousandIsland.Handler
     def handle_connection(_socket, state) do
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 
@@ -71,7 +71,7 @@ defmodule ThousandIsland.SocketTest do
         "#{inspect([local_info, peer_info, negotiated_protocol])}"
       )
 
-      {:ok, :close, state}
+      {:close, state}
     end
   end
 


### PR DESCRIPTION
This change refactors `{:ok, :continue,..}` and `{:ok, :close,...}` tuples as returned by `c:handle_connection/2` and `c:handle_data/3`. Specifically, it drops the `:ok` and just uses `{:continue,...}` and `{:close,...}`. The previous format was largely redundant & this brings our return tuples into line with how most libraries work.

This is a breaking change, to be noted in the 0.5.x release.