### PR TITLE
Add callback to pass GenServer options to handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ thousand_island-*.tar
 
 # Ignore dialyzer caches
 /priv/plts/
+
+
+# ElixirLS
+/.elixir_ls

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -37,7 +37,7 @@ defmodule ThousandIsland do
 
   ## Starting a Thousand Island Server
 
-  A typical use of `ThousandIsland` might look like the following: 
+  A typical use of `ThousandIsland` might look like the following:
 
   ```elixir
   defmodule MyApp.Supervisor do
@@ -81,7 +81,7 @@ defmodule ThousandIsland do
 
   ## Logging & Telemetry
 
-  As a low-level library, Thousand Island purposely does not do any inline 
+  As a low-level library, Thousand Island purposely does not do any inline
   logging of any kind. The `ThousandIsland.Logging` module defines a number of
   functions to aid in tracing connections at various log levels, and such logging
   can be dynamically enabled and disabled against an already running server. This
@@ -106,8 +106,8 @@ defmodule ThousandIsland do
   * `[:socket, :shutdown]`: Emitted whenever a `ThousandIsland.Socket.shutdown/2` call completes.
   * `[:socket, :close]`: Emitted whenever a `ThousandIsland.Socket.close/1` call completes.
 
-  Where meaurements indicate a time duration they are are expressed in `System` 
-  `:native` units for performance reasons. They can be conveted to any desired 
+  Where meaurements indicate a time duration they are are expressed in `System`
+  `:native` units for performance reasons. They can be conveted to any desired
   time unit via `System.convert_time_unit/3`.
   """
 
@@ -116,7 +116,7 @@ defmodule ThousandIsland do
 
   * `handler_module`: The name of the module used to handle connections to this server.
   The module is expected to implement the `ThousandIsland.Handler` behaviour. Required.
-  * `handler_options`: A term which is passed as the initial state value to 
+  * `handler_options`: A term which is passed as the initial state value to
   `c:ThousandIsland.Handler.handle_connection/2` calls. Optional, defaulting to nil.
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
@@ -129,13 +129,14 @@ defmodule ThousandIsland do
   `c:ThousandIsland.Transport.listen/2` function. Valid values depend on the transport
   module specified in `transport_module` and can be found in the documentation for the
   `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL` modules. Any options
-  in terms of interfaces to listen to / certificates and keys to use for SSL connections 
+  in terms of interfaces to listen to / certificates and keys to use for SSL connections
   will be passed in via this option.
   * `num_acceptors`: The numbner of acceptor processes to run. Defaults to 10.
   """
   @type options :: [
           handler_module: module(),
           handler_options: term(),
+          genserver_options: GenServer.options(),
           port: :inet.port_number(),
           transport_module: module(),
           transport_options: keyword(),
@@ -178,10 +179,10 @@ defmodule ThousandIsland do
   end
 
   @doc """
-  Synchronously stops the given server, waiting up to the given number of milliseconds 
-  for existing connections to finish up. Immediately upon calling this function, 
+  Synchronously stops the given server, waiting up to the given number of milliseconds
+  for existing connections to finish up. Immediately upon calling this function,
   the server stops listening for new connections, and then proceeds to wait until
-  either all existing connections have completed or the specified timeout has 
+  either all existing connections have completed or the specified timeout has
   elapsed.
   """
   @spec stop(pid(), timeout()) :: :ok

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -118,6 +118,8 @@ defmodule ThousandIsland do
   The module is expected to implement the `ThousandIsland.Handler` behaviour. Required.
   * `handler_options`: A term which is passed as the initial state value to
   `c:ThousandIsland.Handler.handle_connection/2` calls. Optional, defaulting to nil.
+  * `genserver_options`: A term which is passed as the value to the handler module's
+  underlying `GenServer.start_link/3` call. Optional, defaulting to [].
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
   which can then be obtained via `local_port/1`.

--- a/lib/thousand_island/connection.ex
+++ b/lib/thousand_island/connection.ex
@@ -4,7 +4,8 @@ defmodule ThousandIsland.Connection do
   def start(sup_pid, transport_socket, acceptor_id, %ThousandIsland.ServerConfig{
         transport_module: transport_module,
         handler_module: handler_module,
-        handler_opts: handler_opts
+        handler_opts: handler_opts,
+        genserver_opts: genserver_opts
       }) do
     connection_id = unique_id()
 
@@ -12,7 +13,11 @@ defmodule ThousandIsland.Connection do
     # the process which owns the socket (us, at this point).
 
     # Start by creating the worker process which will eventually handle this socket
-    {:ok, pid} = DynamicSupervisor.start_child(sup_pid, {handler_module, handler_opts})
+    {:ok, pid} =
+      DynamicSupervisor.start_child(
+        sup_pid,
+        {handler_module, [handler_opts: handler_opts, genserver_opts: genserver_opts]}
+      )
 
     # Since this process owns the socket at this point, it needs to be the
     # one to make this call. connection_pid is sitting and waiting for the

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -86,7 +86,7 @@ defmodule ThousandIsland.Handler do
   which are able to make use of the underlying socket. This allows for bidirectional sending and receiving of messages in
   an asynchronous manner.
 
-  You can pass options to the default handler underlying `GenServer` by adding a `genserver_opts` key to `handler_opts`
+  You can pass options to the default handler underlying `GenServer` by passing a `genserver_options` key to `ThousandIsland.start_link/1`
   containing `t:GenServer.options/0` to be passed to the last argument of `GenServer.start_link/3`.
 
   Please note that you should not pass the `name` `t:Genserver.option/0`. If you need to register handler processes for
@@ -275,8 +275,7 @@ defmodule ThousandIsland.Handler do
 
       defoverridable ThousandIsland.Handler
 
-      def start_link(arg) do
-        {genserver_opts, handler_opts} = Keyword.pop(arg, :genserver_opts, [])
+      def start_link(handler_opts: handler_opts, genserver_opts: genserver_opts) do
         GenServer.start_link(__MODULE__, handler_opts, genserver_opts)
       end
 

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -220,10 +220,11 @@ defmodule ThousandIsland.Handler do
 
   @doc """
   This callback is called when the handler process is started and allows to pass options to the `GenServer` process at startup.
-  This can be useful if you need to e.g. register the process using a via-tuple for later lookup or enable `GenServer` debug.
+  It is called with the server's configured `handler_options` value as initial state. This can be useful if you need to
+  e.g. register the process using a via-tuple for later lookup or enable `GenServer` debug.
   By default, not options are passed.
   """
-  @callback options :: GenServer.options()
+  @callback options(state :: term) :: GenServer.options()
 
   @optional_callbacks handle_connection: 2,
                       handle_data: 3,
@@ -231,7 +232,7 @@ defmodule ThousandIsland.Handler do
                       handle_error: 3,
                       handle_shutdown: 2,
                       handle_timeout: 2,
-                      options: 0
+                      options: 1
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -248,12 +249,12 @@ defmodule ThousandIsland.Handler do
       def handle_error(_error, _socket, _state), do: :ok
       def handle_shutdown(_socket, _state), do: :ok
       def handle_timeout(_socket, _state), do: :ok
-      def options, do: []
+      def options(_state), do: []
 
       defoverridable ThousandIsland.Handler
 
       def start_link(arg) do
-        GenServer.start_link(__MODULE__, arg, __MODULE__.options())
+        GenServer.start_link(__MODULE__, arg, __MODULE__.options(arg))
       end
 
       @impl GenServer

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -6,7 +6,7 @@ defmodule ThousandIsland.Handler do
 
   The lifecycle of a Handler instance is as follows:
 
-  1. After a client connection to a Thousand Island server is made, Thousand Island will complete the initial setup of the 
+  1. After a client connection to a Thousand Island server is made, Thousand Island will complete the initial setup of the
   connection (performing a TLS handshake, for example), and then call `c:handle_connection/2`.
 
   2. A handler implementation may choose to process a client connection within the `c:handle_connection/2` callback by
@@ -14,22 +14,22 @@ defmodule ThousandIsland.Handler do
   an implementation & the value `{:close, state}` can be returned which will cause Thousand Island to close the connection
   to the client.
 
-  3. In cases where the server wishes to keep the connection open and wait for subsequent requests from the client on the 
+  3. In cases where the server wishes to keep the connection open and wait for subsequent requests from the client on the
   same socket, it may elect to return `{:continue, state}`. This will cause Thousand Island to wait for client data
-  asynchronously; `c:handle_data/3` will be invoked when the client sends more data. 
+  asynchronously; `c:handle_data/3` will be invoked when the client sends more data.
 
   4. In the meantime, the process which is hosting connection is idle & able to receive messages sent from elsewhere in your
   application as needed. The implementation included in the `use ThousandIsland.Handler` macro uses a `GenServer` structure,
   so you may implement such behaviour via standard `GenServer` patterns. Note that in these cases that state is provided (and
   must be returned) in a `{socket, state}` format, where the second tuple is the same state value that is passed to the various `handle_*` callbacks
-  defined on this behaviour. Note also that any `GenServer` `handle_*` calls which are processed directly by an implementing module 
+  defined on this behaviour. Note also that any `GenServer` `handle_*` calls which are processed directly by an implementing module
   will cancel any async read timeout values which may have been set. Such calls are able to reset the timeout by returning a four element
   tuple with `timeout` as the fourth argument as specified in the `GenServer` documentation.
 
   It is fully supported to intermix synchronous `ThousandIsland.Socket.recv` calls with async return values from `c:handle_connection/2`
-  and `c:handle_data/3` callbacks. 
+  and `c:handle_data/3` callbacks.
 
-  # Example 
+  # Example
 
   A simple example of a Hello World server is as follows:
 
@@ -60,7 +60,7 @@ defmodule ThousandIsland.Handler do
   ```
 
   Note that in this example there is no `c:handle_connection/2` callback defined. The default implementation of this
-  callback will simply return `{:continue, state}`, which is appropriate for cases where the client is the first 
+  callback will simply return `{:continue, state}`, which is appropriate for cases where the client is the first
   party to communicate.
 
   Another example of a server which can send and receive messages asynchronously is as follows:
@@ -85,6 +85,38 @@ defmodule ThousandIsland.Handler do
   Note that in this example we make use of the fact that the handler process is really just a GenServer to send it messages
   which are able to make use of the underlying socket. This allows for bidirectional sending and receiving of messages in
   an asynchronous manner.
+
+  You can pass options to the default handler underlying `GenServer` by adding a `genserver_opts` key to `handler_opts`
+  containing `t:GenServer.options/0` to be passed to the last argument of `GenServer.start_link/3`.
+
+  Please note that you should not pass the `name` `t:Genserver.option/0`. If you need to register handler processes for
+  later lookup and use, you should perform process registration in `handle_connection/2`, ensuring the handler process is
+  registered only after the underlying connection is established and you have access to the connection socket and metadata
+  via `ThousandIsland.Socket.peer_info/1`.
+
+  For example, using a custom process registry via `Registry`:
+
+  ```elixir
+
+    defmodule Messenger do
+    use ThousandIsland.Handler
+
+    @impl ThousandIsland.Handler
+    def handle_connection(socket, state) do
+      %{address: host} = ThousandIsland.Socket.peer_info(socket)
+      {:ok, _pid} = Registry.register(MessengerRegistry, {state[:my_key], address}, nil)
+      {:continue, state}
+    end
+
+    @impl ThousandIsland.Handler
+    def handle_data(data, socket, state) do
+      ThousandIsland.Socket.send(socket, data)
+      {:continue, state}
+    end
+  end
+  ```
+
+  This example assumes you have started a `Registry` and registered it under the name `MessengerRegistry`.
 
   # When Handler Isn't Enough
 
@@ -132,15 +164,15 @@ defmodule ThousandIsland.Handler do
 
   The value returned by this callback causes Thousand Island to proceed in once of several ways:
 
-  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to 
+  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to
   allow final cleanup to be done.
-  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the 
+  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the
   client subsequently sends data (or if there is already unread data waiting from the client), Thousand Island will call
   `c:handle_data/3` to allow this data to be processed.
   * Returning `{:continue, state, timeout}` is identical to the previous case with the
   addition of a timeout. If `timeout` milliseconds passes with no data being received, the socket
   will be closed and `c:handle_timeout/2` will be called.
-  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to 
+  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to
   allow final cleanup to be done.
   """
   @callback handle_connection(socket :: ThousandIsland.Socket.t(), state :: term()) ::
@@ -148,20 +180,20 @@ defmodule ThousandIsland.Handler do
 
   @doc """
   This callback is called whenever client data is received after `c:handle_connection/2` or `c:handle_data/3` have returned an
-  `{:continue, state}` tuple. The data received is passed as the first argument, and handlers may choose to interact 
+  `{:continue, state}` tuple. The data received is passed as the first argument, and handlers may choose to interact
   synchronously with the socket in this callback via calls to various `ThousandIsland.Socket` functions.
 
   The value returned by this callback causes Thousand Island to proceed in once of several ways:
 
-  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to 
+  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to
   allow final cleanup to be done.
-  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the 
+  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the
   client subsequently sends data (or if there is already unread data waiting from the client), Thousand Island will call
   `c:handle_data/3` to allow this data to be processed.
   * Returning `{:continue, state, timeout}` is identical to the previous case with the
   addition of a timeout. If `timeout` milliseconds passes with no data being received, the socket
   will be closed and `c:handle_timeout/2` will be called.
-  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to 
+  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to
   allow final cleanup to be done.
   """
   @callback handle_data(data :: binary(), socket :: ThousandIsland.Socket.t(), state :: term()) ::
@@ -172,7 +204,7 @@ defmodule ThousandIsland.Handler do
   as it is the last callback called before the process backing this connection is terminated. The underlying socket
   has already been closed by the time this callback is called. The return value is ignored.
 
-  This callback is not called if the connection is explicitly closed via `ThousandIsland.Socket.close/1`, however it 
+  This callback is not called if the connection is explicitly closed via `ThousandIsland.Socket.close/1`, however it
   will be called in cases where `handle_connection/2` or `handle_data/3` return a `{:close, state}` tuple.
   """
   @callback handle_close(socket :: ThousandIsland.Socket.t(), state :: term()) :: term()
@@ -197,8 +229,8 @@ defmodule ThousandIsland.Handler do
   as it is the last callback called before the process backing this connection is terminated. The underlying socket
   has NOT been closed by the time this callback is called. The return value is ignored.
 
-  This callback is only called when the shutdown reason is `:normal`, and is subject to the same caveats described 
-  in `c:GenServer.terminate/2`. 
+  This callback is only called when the shutdown reason is `:normal`, and is subject to the same caveats described
+  in `c:GenServer.terminate/2`.
   """
   @callback handle_shutdown(
               socket :: ThousandIsland.Socket.t(),
@@ -207,7 +239,7 @@ defmodule ThousandIsland.Handler do
               term()
 
   @doc """
-  This callback is called when an async read call times out (ie: when a tuple of the form `{:continue, state, timeout}` 
+  This callback is called when an async read call times out (ie: when a tuple of the form `{:continue, state, timeout}`
   is returned by `c:handle_connection/2` or `c:handle_data/3` and `timeout` ms have passed). Note that it is NOT called
   on explicit `ThousandIsland.Socket.recv/3` calls as they have their own timeout semantics. The underlying socket
   has NOT been closed by the time this callback is called. The return value is ignored.
@@ -218,21 +250,12 @@ defmodule ThousandIsland.Handler do
             ) ::
               term()
 
-  @doc """
-  This callback is called when the handler process is started and allows to pass options to the `GenServer` process at startup.
-  It is called with the server's configured `handler_options` value as initial state. This can be useful if you need to
-  e.g. register the process using a via-tuple for later lookup or enable `GenServer` debug.
-  By default, not options are passed.
-  """
-  @callback options(state :: term) :: GenServer.options()
-
   @optional_callbacks handle_connection: 2,
                       handle_data: 3,
                       handle_close: 2,
                       handle_error: 3,
                       handle_shutdown: 2,
-                      handle_timeout: 2,
-                      options: 1
+                      handle_timeout: 2
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -249,12 +272,12 @@ defmodule ThousandIsland.Handler do
       def handle_error(_error, _socket, _state), do: :ok
       def handle_shutdown(_socket, _state), do: :ok
       def handle_timeout(_socket, _state), do: :ok
-      def options(_state), do: []
 
       defoverridable ThousandIsland.Handler
 
       def start_link(arg) do
-        GenServer.start_link(__MODULE__, arg, __MODULE__.options(arg))
+        {genserver_opts, handler_opts} = Keyword.pop(arg, :genserver_opts, [])
+        GenServer.start_link(__MODULE__, handler_opts, genserver_opts)
       end
 
       @impl GenServer

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -218,12 +218,20 @@ defmodule ThousandIsland.Handler do
             ) ::
               term()
 
+  @doc """
+  This callback is called when the handler process is started and allows to pass options to the `GenServer` process at startup.
+  This can be useful if you need to e.g. register the process using a via-tuple for later lookup or enable `GenServer` debug.
+  By default, not options are passed.
+  """
+  @callback options :: GenServer.options()
+
   @optional_callbacks handle_connection: 2,
                       handle_data: 3,
                       handle_close: 2,
                       handle_error: 3,
                       handle_shutdown: 2,
-                      handle_timeout: 2
+                      handle_timeout: 2,
+                      options: 0
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -240,11 +248,12 @@ defmodule ThousandIsland.Handler do
       def handle_error(_error, _socket, _state), do: :ok
       def handle_shutdown(_socket, _state), do: :ok
       def handle_timeout(_socket, _state), do: :ok
+      def options, do: []
 
       defoverridable ThousandIsland.Handler
 
       def start_link(arg) do
-        GenServer.start_link(__MODULE__, arg)
+        GenServer.start_link(__MODULE__, arg, __MODULE__.options())
       end
 
       @impl GenServer

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -8,6 +8,7 @@ defmodule ThousandIsland.ServerConfig do
           transport_opts: keyword(),
           handler_module: module(),
           handler_opts: term(),
+          genserver_opts: GenServer.options(),
           num_acceptors: pos_integer()
         }
 
@@ -18,6 +19,7 @@ defmodule ThousandIsland.ServerConfig do
           transport_opts: keyword(),
           handler_module: module(),
           handler_opts: keyword(),
+          genserver_opts: GenServer.options(),
           num_acceptors: pos_integer()
         ]
 
@@ -27,6 +29,7 @@ defmodule ThousandIsland.ServerConfig do
     :transport_opts,
     :handler_module,
     :handler_opts,
+    :genserver_opts,
     :num_acceptors
   ]
 
@@ -38,6 +41,7 @@ defmodule ThousandIsland.ServerConfig do
       transport_opts: Keyword.get(opts, :transport_options, []),
       handler_module: Keyword.fetch!(opts, :handler_module),
       handler_opts: Keyword.get(opts, :handler_options, []),
+      genserver_opts: Keyword.get(opts, :genserver_options, []),
       num_acceptors: Keyword.get(opts, :num_acceptors, 10)
     }
   end


### PR DESCRIPTION
Currently if you want to pass some option to the GenServer you need to implement your own GenServer, which is fairly more complicated than just the `use ThousandIsland.Handler` way.

Personally, I need to register handlers using `GenServer.start_link/3` and passing `name: {:via, Registry, {MyRegistry, term}}` to be able to later retrieve handler processes at runtime to be able to call them.

This looked pretty straightforward so I simply drafted the PR.