### PR TITLE
Check result of `ThousandIsland.Socket.handshake/1`

### DIFF
--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -271,8 +271,6 @@ defmodule ThousandIsland.Handler do
           {:error, reason} ->
             {:stop, reason, {socket, state}}
         end
-
-        {:noreply, {socket, state}, {:continue, :handle_connection}}
       end
 
       # Use a continue pattern here so that we have committed the socket

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -264,7 +264,14 @@ defmodule ThousandIsland.Handler do
           acceptor_id: socket.acceptor_id
         })
 
-        ThousandIsland.Socket.handshake(socket)
+        case ThousandIsland.Socket.handshake(socket) do
+          {:ok, socket} ->
+            {:noreply, {socket, state}, {:continue, :handle_connection}}
+
+          {:error, reason} ->
+            {:stop, reason, {socket, state}}
+        end
+
         {:noreply, {socket, state}, {:continue, :handle_connection}}
       end
 

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -155,6 +155,31 @@ defmodule ThousandIsland.SocketTest do
   describe "behaviour specific to ssl" do
     setup :ssl_setup
 
+    test "it should return an error if the handshake fails", context do
+      {:ok, port} = start_handler(Closer, context.server_opts)
+
+      {:error, {:tls_alert, _}} =
+        context.client_mod.connect('localhost', port,
+          active: false,
+          ciphers: [%{cipher: :rc4_128, key_exchange: :rsa, mac: :md5, prf: :default_prf}],
+          verify: :verify_peer,
+          cacertfile: Path.join(__DIR__, "../support/ca.pem"),
+          alpn_advertised_protocols: ["foo"]
+        )
+    end
+
+    test "it should return an error if the ca certificate doesn't exist", context do
+      {:ok, port} = start_handler(Closer, context.server_opts)
+
+      {:error, {:options, _}} =
+        context.client_mod.connect('localhost', port,
+          active: false,
+          verify: :verify_peer,
+          cacertfile: Path.join(__DIR__, "./not/a/file"),
+          alpn_advertised_protocols: ["foo"]
+        )
+    end
+
     test "it should provide correct connection info", context do
       {:ok, port} = start_handler(Info, context.server_opts)
 

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -155,31 +155,6 @@ defmodule ThousandIsland.SocketTest do
   describe "behaviour specific to ssl" do
     setup :ssl_setup
 
-    test "it should return an error if the handshake fails", context do
-      {:ok, port} = start_handler(Closer, context.server_opts)
-
-      {:error, {:tls_alert, _}} =
-        context.client_mod.connect('localhost', port,
-          active: false,
-          ciphers: [%{cipher: :rc4_128, key_exchange: :rsa, mac: :md5, prf: :default_prf}],
-          verify: :verify_peer,
-          cacertfile: Path.join(__DIR__, "../support/ca.pem"),
-          alpn_advertised_protocols: ["foo"]
-        )
-    end
-
-    test "it should return an error if the ca certificate doesn't exist", context do
-      {:ok, port} = start_handler(Closer, context.server_opts)
-
-      {:error, {:options, _}} =
-        context.client_mod.connect('localhost', port,
-          active: false,
-          verify: :verify_peer,
-          cacertfile: Path.join(__DIR__, "./not/a/file"),
-          alpn_advertised_protocols: ["foo"]
-        )
-    end
-
     test "it should provide correct connection info", context do
       {:ok, port} = start_handler(Info, context.server_opts)
 


### PR DESCRIPTION
Added a check for the `ThousandIsland.Socket.handshake/1` return value, in case it fails (e.g. if the path to the tls cert is messed up).

PS: Sorry for the many changes, but my editor removed the whitespaces at the end of the lines.
The real change is just the `case` statement at the bottom.