### PR TITLE
support Socket.getopts/2

### DIFF
--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -28,6 +28,17 @@ defmodule ThousandIsland.Socket do
   end
 
   @doc """
+  Gets the given flags on the socket
+
+  Errors are usually from :inet.posix(), however, SSL module defines return type as any()
+  """
+  @spec getopts(t(), Transport.socket_get_options()) ::
+          {:ok, Transport.socket_set_options()} | {:error, term()}
+  def getopts(%__MODULE__{socket: socket, transport_module: transport_module}, options) do
+    transport_module.getopts(socket, options)
+  end
+
+  @doc """
   Handshakes the underlying socket if it is required (as in the case of SSL sockets, for example).
   """
   @spec handshake(t()) :: {:ok, t()} | {:error, String.t()}
@@ -133,8 +144,10 @@ defmodule ThousandIsland.Socket do
 
   @doc """
   Sets the given flags on the socket
+
+  Errors are usually from :inet.posix(), however, SSL module defines return type as any()
   """
-  @spec setopts(t(), Transport.socket_options()) :: :ok | {:error, String.t()}
+  @spec setopts(t(), Transport.socket_set_options()) :: :ok | {:error, term()}
   def setopts(%__MODULE__{socket: socket, transport_module: transport_module}, options) do
     transport_module.setopts(socket, options)
   end

--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -24,8 +24,11 @@ defmodule ThousandIsland.Transport do
   @typedoc "Connection statistics for a given socket"
   @type socket_stats() :: {:ok, [{:inet.stat_option(), integer()}]} | {:error, :inet.posix()}
 
-  @typedoc "Options which can be set on a socket via setopts/2"
-  @type socket_options() :: [:inet.socket_setopt()]
+  @typedoc "Options which can be set on a socket via setopts/2 (or returned from getopts/1)"
+  @type socket_get_options() :: [:inet.socket_getopt()]
+
+  @typedoc "Options which can be set on a socket via setopts/2 (or returned from getopts/1)"
+  @type socket_set_options() :: [:inet.socket_setopt()]
 
   @typedoc "The direction in which to shutdown a connection in advance of closing it"
   @type way() :: :read | :write | :read_write
@@ -96,10 +99,16 @@ defmodule ThousandIsland.Transport do
               {:ok, non_neg_integer()} | {:error, String.t()}
 
   @doc """
+  Gets the given options on the socket.
+  """
+  @callback getopts(socket(), socket_get_options()) ::
+              {:ok, socket_set_options()} | {:error, String.t()}
+
+  @doc """
   Sets the given options on the socket. Should disallow setting of options which
   are not compatible with Thousand Island
   """
-  @callback setopts(socket(), socket_options()) :: :ok | {:error, String.t()}
+  @callback setopts(socket(), socket_set_options()) :: :ok | {:error, String.t()}
 
   @doc """
   Shuts down the socket in the given direction.

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -104,6 +104,9 @@ defmodule ThousandIsland.Transports.SSL do
   end
 
   @impl Transport
+  defdelegate getopts(socket, options), to: :ssl
+
+  @impl Transport
   defdelegate setopts(socket, options), to: :ssl
 
   @impl Transport

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -85,6 +85,9 @@ defmodule ThousandIsland.Transports.TCP do
   end
 
   @impl Transport
+  defdelegate getopts(socket, options), to: :inet
+
+  @impl Transport
   defdelegate setopts(socket, options), to: :inet
 
   @impl Transport


### PR DESCRIPTION
We already have support for Socket.setopts/2, so also add support
for getopts/2 to read socket options

Note: also correcting the type specifications for {:error, error}
results, which are defined as being Posix error results in general,
however, the SSL app defines it's errors as any(), so we go
with the widest definition