### PR TITLE
Mix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ complete description, consult `ThousandIsland.start_link/1`):
 
 * `handler_module`: The name of the module used to handle connections to this server.
 The module is expected to implement the `ThousandIsland.Handler` behaviour. Required.
-* `handler_options`: A term which is passed as the initial state value to 
+* `handler_options`: A term which is passed as the initial state value to
 `c:ThousandIsland.Handler.handle_connection/2` calls. Optional, defaulting to nil.
 * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
 * `transport_module`: The name of the module which provides basic socket functions.

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -37,7 +37,7 @@ defmodule ThousandIsland do
 
   ## Starting a Thousand Island Server
 
-  A typical use of `ThousandIsland` might look like the following: 
+  A typical use of `ThousandIsland` might look like the following:
 
   ```elixir
   defmodule MyApp.Supervisor do
@@ -81,7 +81,7 @@ defmodule ThousandIsland do
 
   ## Logging & Telemetry
 
-  As a low-level library, Thousand Island purposely does not do any inline 
+  As a low-level library, Thousand Island purposely does not do any inline
   logging of any kind. The `ThousandIsland.Logging` module defines a number of
   functions to aid in tracing connections at various log levels, and such logging
   can be dynamically enabled and disabled against an already running server. This
@@ -106,8 +106,8 @@ defmodule ThousandIsland do
   * `[:socket, :shutdown]`: Emitted whenever a `ThousandIsland.Socket.shutdown/2` call completes.
   * `[:socket, :close]`: Emitted whenever a `ThousandIsland.Socket.close/1` call completes.
 
-  Where meaurements indicate a time duration they are are expressed in `System` 
-  `:native` units for performance reasons. They can be conveted to any desired 
+  Where meaurements indicate a time duration they are are expressed in `System`
+  `:native` units for performance reasons. They can be conveted to any desired
   time unit via `System.convert_time_unit/3`.
   """
 
@@ -116,7 +116,7 @@ defmodule ThousandIsland do
 
   * `handler_module`: The name of the module used to handle connections to this server.
   The module is expected to implement the `ThousandIsland.Handler` behaviour. Required.
-  * `handler_options`: A term which is passed as the initial state value to 
+  * `handler_options`: A term which is passed as the initial state value to
   `c:ThousandIsland.Handler.handle_connection/2` calls. Optional, defaulting to nil.
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
@@ -129,7 +129,7 @@ defmodule ThousandIsland do
   `c:ThousandIsland.Transport.listen/2` function. Valid values depend on the transport
   module specified in `transport_module` and can be found in the documentation for the
   `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL` modules. Any options
-  in terms of interfaces to listen to / certificates and keys to use for SSL connections 
+  in terms of interfaces to listen to / certificates and keys to use for SSL connections
   will be passed in via this option.
   * `num_acceptors`: The numbner of acceptor processes to run. Defaults to 10.
   """
@@ -178,10 +178,10 @@ defmodule ThousandIsland do
   end
 
   @doc """
-  Synchronously stops the given server, waiting up to the given number of milliseconds 
-  for existing connections to finish up. Immediately upon calling this function, 
+  Synchronously stops the given server, waiting up to the given number of milliseconds
+  for existing connections to finish up. Immediately upon calling this function,
   the server stops listening for new connections, and then proceeds to wait until
-  either all existing connections have completed or the specified timeout has 
+  either all existing connections have completed or the specified timeout has
   elapsed.
   """
   @spec stop(pid(), timeout()) :: :ok

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -6,7 +6,7 @@ defmodule ThousandIsland.Handler do
 
   The lifecycle of a Handler instance is as follows:
 
-  1. After a client connection to a Thousand Island server is made, Thousand Island will complete the initial setup of the 
+  1. After a client connection to a Thousand Island server is made, Thousand Island will complete the initial setup of the
   connection (performing a TLS handshake, for example), and then call `c:handle_connection/2`.
 
   2. A handler implementation may choose to process a client connection within the `c:handle_connection/2` callback by
@@ -14,22 +14,22 @@ defmodule ThousandIsland.Handler do
   an implementation & the value `{:close, state}` can be returned which will cause Thousand Island to close the connection
   to the client.
 
-  3. In cases where the server wishes to keep the connection open and wait for subsequent requests from the client on the 
+  3. In cases where the server wishes to keep the connection open and wait for subsequent requests from the client on the
   same socket, it may elect to return `{:continue, state}`. This will cause Thousand Island to wait for client data
-  asynchronously; `c:handle_data/3` will be invoked when the client sends more data. 
+  asynchronously; `c:handle_data/3` will be invoked when the client sends more data.
 
   4. In the meantime, the process which is hosting connection is idle & able to receive messages sent from elsewhere in your
   application as needed. The implementation included in the `use ThousandIsland.Handler` macro uses a `GenServer` structure,
   so you may implement such behaviour via standard `GenServer` patterns. Note that in these cases that state is provided (and
   must be returned) in a `{socket, state}` format, where the second tuple is the same state value that is passed to the various `handle_*` callbacks
-  defined on this behaviour. Note also that any `GenServer` `handle_*` calls which are processed directly by an implementing module 
+  defined on this behaviour. Note also that any `GenServer` `handle_*` calls which are processed directly by an implementing module
   will cancel any async read timeout values which may have been set. Such calls are able to reset the timeout by returning a four element
   tuple with `timeout` as the fourth argument as specified in the `GenServer` documentation.
 
   It is fully supported to intermix synchronous `ThousandIsland.Socket.recv` calls with async return values from `c:handle_connection/2`
-  and `c:handle_data/3` callbacks. 
+  and `c:handle_data/3` callbacks.
 
-  # Example 
+  # Example
 
   A simple example of a Hello World server is as follows:
 
@@ -60,7 +60,7 @@ defmodule ThousandIsland.Handler do
   ```
 
   Note that in this example there is no `c:handle_connection/2` callback defined. The default implementation of this
-  callback will simply return `{:continue, state}`, which is appropriate for cases where the client is the first 
+  callback will simply return `{:continue, state}`, which is appropriate for cases where the client is the first
   party to communicate.
 
   Another example of a server which can send and receive messages asynchronously is as follows:
@@ -132,15 +132,15 @@ defmodule ThousandIsland.Handler do
 
   The value returned by this callback causes Thousand Island to proceed in once of several ways:
 
-  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to 
+  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to
   allow final cleanup to be done.
-  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the 
+  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the
   client subsequently sends data (or if there is already unread data waiting from the client), Thousand Island will call
   `c:handle_data/3` to allow this data to be processed.
   * Returning `{:continue, state, timeout}` is identical to the previous case with the
   addition of a timeout. If `timeout` milliseconds passes with no data being received, the socket
   will be closed and `c:handle_timeout/2` will be called.
-  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to 
+  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to
   allow final cleanup to be done.
   """
   @callback handle_connection(socket :: ThousandIsland.Socket.t(), state :: term()) ::
@@ -148,20 +148,20 @@ defmodule ThousandIsland.Handler do
 
   @doc """
   This callback is called whenever client data is received after `c:handle_connection/2` or `c:handle_data/3` have returned an
-  `{:continue, state}` tuple. The data received is passed as the first argument, and handlers may choose to interact 
+  `{:continue, state}` tuple. The data received is passed as the first argument, and handlers may choose to interact
   synchronously with the socket in this callback via calls to various `ThousandIsland.Socket` functions.
 
   The value returned by this callback causes Thousand Island to proceed in once of several ways:
 
-  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to 
+  * Returning `{:close, state}` will cause Thousand Island to close the socket & call the `c:handle_close/2` callback to
   allow final cleanup to be done.
-  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the 
+  * Returning `{:continue, state}` will cause Thousand Island to switch the socket to an asynchronous mode. When the
   client subsequently sends data (or if there is already unread data waiting from the client), Thousand Island will call
   `c:handle_data/3` to allow this data to be processed.
   * Returning `{:continue, state, timeout}` is identical to the previous case with the
   addition of a timeout. If `timeout` milliseconds passes with no data being received, the socket
   will be closed and `c:handle_timeout/2` will be called.
-  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to 
+  * Returning `{:error, reason, state}` will cause Thousand Island to close the socket & call the `c:handle_error/3` callback to
   allow final cleanup to be done.
   """
   @callback handle_data(data :: binary(), socket :: ThousandIsland.Socket.t(), state :: term()) ::
@@ -172,7 +172,7 @@ defmodule ThousandIsland.Handler do
   as it is the last callback called before the process backing this connection is terminated. The underlying socket
   has already been closed by the time this callback is called. The return value is ignored.
 
-  This callback is not called if the connection is explicitly closed via `ThousandIsland.Socket.close/1`, however it 
+  This callback is not called if the connection is explicitly closed via `ThousandIsland.Socket.close/1`, however it
   will be called in cases where `handle_connection/2` or `handle_data/3` return a `{:close, state}` tuple.
   """
   @callback handle_close(socket :: ThousandIsland.Socket.t(), state :: term()) :: term()
@@ -197,8 +197,8 @@ defmodule ThousandIsland.Handler do
   as it is the last callback called before the process backing this connection is terminated. The underlying socket
   has NOT been closed by the time this callback is called. The return value is ignored.
 
-  This callback is only called when the shutdown reason is `:normal`, and is subject to the same caveats described 
-  in `c:GenServer.terminate/2`. 
+  This callback is only called when the shutdown reason is `:normal`, and is subject to the same caveats described
+  in `c:GenServer.terminate/2`.
   """
   @callback handle_shutdown(
               socket :: ThousandIsland.Socket.t(),
@@ -207,7 +207,7 @@ defmodule ThousandIsland.Handler do
               term()
 
   @doc """
-  This callback is called when an async read call times out (ie: when a tuple of the form `{:continue, state, timeout}` 
+  This callback is called when an async read call times out (ie: when a tuple of the form `{:continue, state, timeout}`
   is returned by `c:handle_connection/2` or `c:handle_data/3` and `timeout` ms have passed). Note that it is NOT called
   on explicit `ThousandIsland.Socket.recv/3` calls as they have their own timeout semantics. The underlying socket
   has NOT been closed by the time this callback is called. The return value is ignored.

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -1,7 +1,7 @@
 defmodule ThousandIsland.Socket do
   @moduledoc """
   Encapsulates a client connection's underlying socket, providing a facility to
-  read, write, and otherwise manipulate a connection from a client. 
+  read, write, and otherwise manipulate a connection from a client.
   """
 
   defstruct socket: nil, transport_module: nil, connection_id: nil, acceptor_id: nil
@@ -28,7 +28,7 @@ defmodule ThousandIsland.Socket do
   end
 
   @doc """
-  Handshakes the underlying socket if it is required (as in the case of SSL sockets, for example). 
+  Handshakes the underlying socket if it is required (as in the case of SSL sockets, for example).
   """
   @spec handshake(t()) :: {:ok, t()} | {:error, String.t()}
   def handshake(
@@ -54,8 +54,8 @@ defmodule ThousandIsland.Socket do
 
   @doc """
   Returns available bytes on the given socket. Up to `num_bytes` bytes will be
-  returned (0 can be passed in to get the next 'available' bytes, typically the 
-  next packet). If insufficient bytes are available, the function can wait `timeout` 
+  returned (0 can be passed in to get the next 'available' bytes, typically the
+  next packet). If insufficient bytes are available, the function can wait `timeout`
   milliseconds for data to arrive.
   """
   @spec recv(t(), non_neg_integer(), timeout()) :: Transport.on_recv()

--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -1,6 +1,6 @@
 defmodule ThousandIsland.Transport do
   @moduledoc """
-  This module describes the behaviour required for Thousand Island to interact 
+  This module describes the behaviour required for Thousand Island to interact
   with low-level sockets. It is largely internal to Thousand Island, however users
   are free to implement their own versions of this behaviour backed by whatever
   underlying transport they choose. Such a module can be used in Thousand Island
@@ -53,14 +53,14 @@ defmodule ThousandIsland.Transport do
 
   @doc """
   Wait for a client connection on the given listener socket. This call blocks until
-  such a connection arrives, or an error occurs (such as the listener socket being 
+  such a connection arrives, or an error occurs (such as the listener socket being
   closed).
   """
   @callback accept(listener_socket()) :: {:ok, socket()} | {:error, any()}
 
   @doc """
   Performs an initial handshake on a new client connection (such as that done
-  when negotiating an SSL connection). Transports which do not have such a 
+  when negotiating an SSL connection). Transports which do not have such a
   handshake can simply pass the socket through unchanged.
   """
   @callback handshake(socket()) :: on_handshake()
@@ -73,8 +73,8 @@ defmodule ThousandIsland.Transport do
 
   @doc """
   Returns available bytes on the given socket. Up to `num_bytes` bytes will be
-  returned (0 can be passed in to get the next 'available' bytes, typically the 
-  next packet). If insufficient bytes are available, the function can wait `timeout` 
+  returned (0 can be passed in to get the next 'available' bytes, typically the
+  next packet). If insufficient bytes are available, the function can wait `timeout`
   milliseconds for data to arrive.
   """
   @callback recv(socket(), num_bytes :: non_neg_integer(), timeout :: timeout()) :: on_recv()

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -1,20 +1,20 @@
 defmodule ThousandIsland.Transports.SSL do
   @moduledoc """
-  Defines a `ThousandIsland.Transport` implementation based on TCP SSL sockets 
+  Defines a `ThousandIsland.Transport` implementation based on TCP SSL sockets
   as provided by Erlang's `:ssl` module. For the most part, users of Thousand
   Island will only ever need to deal with this module via `transport_options`
   passed to `ThousandIsland` at startup time. A complete list of such options
-  is defined via the `t::ssl.tls_server_option` type. This list can be somewhat 
+  is defined via the `t::ssl.tls_server_option` type. This list can be somewhat
   difficult to decipher; a list of the most common options follows:
 
   * `key`: A DER encoded binary representation of the SSL key to use
   * `cert`: A DER encoded binary representation of the SSL key to use
   * `keyfile`: A string path to a PEM encoded key to use for SSL
   * `certfile`: A string path to a PEM encoded cert to use for SSL
-  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be 
-  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can 
+  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be
+  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can
   be used to only bind to localhost. On platforms which support it (macOS and
-  Linux at a minimum, likely others), you can also bind to a Unix domain socket 
+  Linux at a minimum, likely others), you can also bind to a Unix domain socket
   by specifying a value of `ip: {:local, "/path/to/socket"}`. Note that the port
   *must* be set to `0`, and that the socket is not removed from the filesystem
   after the server shuts down.

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -1,17 +1,17 @@
 defmodule ThousandIsland.Transports.TCP do
   @moduledoc """
-  Defines a `ThousandIsland.Transport` implementation based on clear TCP sockets 
+  Defines a `ThousandIsland.Transport` implementation based on clear TCP sockets
   as provided by Erlang's `:gen_tcp` module. For the most part, users of Thousand
   Island will only ever need to deal with this module via `transport_options`
   passed to `ThousandIsland` at startup time. A complete list of such options
-  is defined via the `t::gen_tcp.listen_option()` type. This list can be somewhat 
-  difficult to decipher; by far the most common value to pass to this transport 
+  is defined via the `t::gen_tcp.listen_option()` type. This list can be somewhat
+  difficult to decipher; by far the most common value to pass to this transport
   is the following:
 
-  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be 
-  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can 
+  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be
+  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can
   be used to only bind to localhost. On platforms which support it (macOS and
-  Linux at a minimum, likely others), you can also bind to a Unix domain socket 
+  Linux at a minimum, likely others), you can also bind to a Unix domain socket
   by specifying a value of `ip: {:local, "/path/to/socket"}`. Note that the port
   *must* be set to `0`, and that the socket is not removed from the filesystem
   after the server shuts down.


### PR DESCRIPTION
I ran mix format on the lib dir as there were a number of cases of trailing spaces in the docs (just means future patches won't accidentally try to include them).