### PR TITLE
Add `read_timeout`

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -141,14 +141,11 @@ defmodule ThousandIsland do
           genserver_options: GenServer.options(),
           port: :inet.port_number(),
           transport_module: module(),
-          transport_options: transport_opts(),
+          transport_options:
+            ThousandIsland.Transports.TCP.options() | ThousandIsland.Transports.SSL.options(),
           num_acceptors: pos_integer(),
           read_timeout: pos_integer()
         ]
-
-  @type transport_opts() :: [tcp_opts() | ssl_opts()]
-  @type tcp_opts() :: [:inet.inet_backend() | :gen_tcp.listen_option()]
-  @type ssl_opts() :: [:ssl.tls_server_option()]
 
   alias ThousandIsland.{Listener, Server, ServerConfig, Transport}
 

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -141,11 +141,13 @@ defmodule ThousandIsland do
           genserver_options: GenServer.options(),
           port: :inet.port_number(),
           transport_module: module(),
-          transport_options:
-            ThousandIsland.Transports.TCP.options() | ThousandIsland.Transports.SSL.options(),
+          transport_options: transport_options(),
           num_acceptors: pos_integer(),
           read_timeout: pos_integer()
         ]
+
+  @type transport_options() ::
+          ThousandIsland.Transports.TCP.options() | ThousandIsland.Transports.SSL.options()
 
   alias ThousandIsland.{Listener, Server, ServerConfig, Transport}
 

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -169,9 +169,7 @@ defmodule ThousandIsland do
   this module in the case of success, or an error tuple describing the reason the
   server was unable to start in the case of failure.
   """
-  @spec start_link(options()) ::
-          {:ok, pid()}
-          | {:error, {:already_started, pid()} | {:shutdown, term()} | term()}
+  @spec start_link(options()) :: Supervisor.on_start()
   def start_link(opts \\ []) do
     opts
     |> ServerConfig.new()

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -141,9 +141,14 @@ defmodule ThousandIsland do
           genserver_options: GenServer.options(),
           port: :inet.port_number(),
           transport_module: module(),
-          transport_options: keyword(),
-          num_acceptors: pos_integer()
+          transport_options: transport_opts(),
+          num_acceptors: pos_integer(),
+          read_timeout: pos_integer()
         ]
+
+  @type transport_opts() :: [tcp_opts() | ssl_opts()]
+  @type tcp_opts() :: [:inet.inet_backend() | :gen_tcp.listen_option()]
+  @type ssl_opts() :: [:ssl.tls_server_option()]
 
   alias ThousandIsland.{Listener, Server, ServerConfig, Transport}
 
@@ -165,7 +170,9 @@ defmodule ThousandIsland do
   this module in the case of success, or an error tuple describing the reason the
   server was unable to start in the case of failure.
   """
-  @spec start_link(options()) :: {:ok, pid} | {:error, term}
+  @spec start_link(options()) ::
+          {:ok, pid()}
+          | {:error, {:already_started, pid()} | {:shutdown, term()} | term()}
   def start_link(opts \\ []) do
     opts
     |> ServerConfig.new()

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -143,7 +143,7 @@ defmodule ThousandIsland do
           transport_module: module(),
           transport_options: transport_options(),
           num_acceptors: pos_integer(),
-          read_timeout: pos_integer()
+          read_timeout: timeout()
         ]
 
   @type transport_options() ::

--- a/lib/thousand_island/connection.ex
+++ b/lib/thousand_island/connection.ex
@@ -5,7 +5,8 @@ defmodule ThousandIsland.Connection do
         transport_module: transport_module,
         handler_module: handler_module,
         handler_opts: handler_opts,
-        genserver_opts: genserver_opts
+        genserver_opts: genserver_opts,
+        read_timeout: read_timeout
       }) do
     connection_id = unique_id()
 
@@ -31,7 +32,13 @@ defmodule ThousandIsland.Connection do
     # struct and send it to the new process via a message so it can start working
     # with the socket (note that the new process will still need to handshake with the remote end)
     socket =
-      ThousandIsland.Socket.new(transport_socket, transport_module, connection_id, acceptor_id)
+      ThousandIsland.Socket.new(
+        transport_socket,
+        transport_module,
+        connection_id,
+        acceptor_id,
+        read_timeout
+      )
 
     Process.send(pid, {:thousand_island_ready, socket}, [])
   end

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -379,7 +379,7 @@ defmodule ThousandIsland.Handler do
         case continuation do
           {:continue, state} ->
             ThousandIsland.Socket.setopts(socket, active: :once)
-            {:noreply, {socket, state}}
+            {:noreply, {socket, state}, socket.read_timeout}
 
           {:continue, state, timeout} ->
             ThousandIsland.Socket.setopts(socket, active: :once)

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -5,23 +5,12 @@ defmodule ThousandIsland.ServerConfig do
   @type t :: %__MODULE__{
           port: :inet.port_number(),
           transport_module: module(),
-          transport_opts: keyword(),
+          transport_opts: ThousandIsland.transport_opts(),
           handler_module: module(),
           handler_opts: term(),
           genserver_opts: GenServer.options(),
           num_acceptors: pos_integer()
         }
-
-  @typedoc "Valid options when creating a ServerConfig struct"
-  @type options() :: [
-          port: :inet.port_number(),
-          transport_module: module(),
-          transport_opts: keyword(),
-          handler_module: module(),
-          handler_opts: keyword(),
-          genserver_opts: GenServer.options(),
-          num_acceptors: pos_integer()
-        ]
 
   defstruct [
     :port,
@@ -30,10 +19,11 @@ defmodule ThousandIsland.ServerConfig do
     :handler_module,
     :handler_opts,
     :genserver_opts,
-    :num_acceptors
+    :num_acceptors,
+    :read_timeout
   ]
 
-  @spec new(options()) :: t()
+  @spec new(ThousandIsland.options()) :: t()
   def new(opts \\ []) do
     %__MODULE__{
       port: Keyword.get(opts, :port, 4000),
@@ -42,7 +32,8 @@ defmodule ThousandIsland.ServerConfig do
       handler_module: Keyword.fetch!(opts, :handler_module),
       handler_opts: Keyword.get(opts, :handler_options, []),
       genserver_opts: Keyword.get(opts, :genserver_options, []),
-      num_acceptors: Keyword.get(opts, :num_acceptors, 10)
+      num_acceptors: Keyword.get(opts, :num_acceptors, 10),
+      read_timeout: Keyword.get(opts, :read_timeout, :infinity)
     }
   end
 end

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -5,7 +5,7 @@ defmodule ThousandIsland.ServerConfig do
   @type t :: %__MODULE__{
           port: :inet.port_number(),
           transport_module: module(),
-          transport_opts: ThousandIsland.transport_opts(),
+          transport_opts: ThousandIsland.transport_options(),
           handler_module: module(),
           handler_opts: term(),
           genserver_opts: GenServer.options(),

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -9,7 +9,8 @@ defmodule ThousandIsland.ServerConfig do
           handler_module: module(),
           handler_opts: term(),
           genserver_opts: GenServer.options(),
-          num_acceptors: pos_integer()
+          num_acceptors: pos_integer(),
+          read_timeout: timeout()
         }
 
   defstruct [

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -4,7 +4,11 @@ defmodule ThousandIsland.Socket do
   read, write, and otherwise manipulate a connection from a client.
   """
 
-  defstruct socket: nil, transport_module: nil, connection_id: nil, acceptor_id: nil
+  defstruct socket: nil,
+            transport_module: nil,
+            connection_id: nil,
+            acceptor_id: nil,
+            read_timeout: nil
 
   alias ThousandIsland.Transport
 
@@ -13,17 +17,19 @@ defmodule ThousandIsland.Socket do
           socket: Transport.socket(),
           transport_module: module(),
           connection_id: String.t(),
-          acceptor_id: String.t()
+          acceptor_id: String.t(),
+          read_timeout: pos_integer()
         }
 
   @doc false
-  @spec new(Transport.socket(), module(), String.t(), String.t()) :: t()
-  def new(socket, transport_module, connection_id, acceptor_id) do
+  @spec new(Transport.socket(), module(), String.t(), String.t(), pos_integer()) :: t()
+  def new(socket, transport_module, connection_id, acceptor_id, read_timeout) do
     %__MODULE__{
       socket: socket,
       transport_module: transport_module,
       connection_id: connection_id,
-      acceptor_id: acceptor_id
+      acceptor_id: acceptor_id,
+      read_timeout: read_timeout
     }
   end
 
@@ -74,12 +80,13 @@ defmodule ThousandIsland.Socket do
         %__MODULE__{
           socket: socket,
           transport_module: transport_module,
-          connection_id: connection_id
+          connection_id: connection_id,
+          read_timeout: read_timeout
         },
         length \\ 0,
-        timeout \\ :infinity
+        timeout \\ nil
       ) do
-    result = transport_module.recv(socket, length, timeout)
+    result = transport_module.recv(socket, length, timeout || read_timeout)
 
     :telemetry.execute([:socket, :recv], %{result: result}, %{
       connection_id: connection_id

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -75,7 +75,7 @@ defmodule ThousandIsland.Socket do
   next packet). If insufficient bytes are available, the function can wait `timeout`
   milliseconds for data to arrive.
   """
-  @spec recv(t(), non_neg_integer(), timeout()) :: Transport.on_recv()
+  @spec recv(t(), non_neg_integer(), timeout() | nil) :: Transport.on_recv()
   def recv(
         %__MODULE__{
           socket: socket,

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -18,11 +18,11 @@ defmodule ThousandIsland.Socket do
           transport_module: module(),
           connection_id: String.t(),
           acceptor_id: String.t(),
-          read_timeout: pos_integer()
+          read_timeout: timeout()
         }
 
   @doc false
-  @spec new(Transport.socket(), module(), String.t(), String.t(), pos_integer()) :: t()
+  @spec new(Transport.socket(), module(), String.t(), String.t(), timeout()) :: t()
   def new(socket, transport_module, connection_id, acceptor_id, read_timeout) do
     %__MODULE__{
       socket: socket,

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -41,6 +41,8 @@ defmodule ThousandIsland.Transports.SSL do
 
   alias ThousandIsland.Transport
 
+  @type options() :: [:ssl.tls_server_option()]
+
   @behaviour Transport
 
   @hardcoded_options [mode: :binary, active: false]

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -38,6 +38,8 @@ defmodule ThousandIsland.Transports.TCP do
 
   alias ThousandIsland.Transport
 
+  @type options() :: [:inet.inet_backend() | :gen_tcp.listen_option()]
+
   @behaviour Transport
 
   @hardcoded_options [mode: :binary, active: false]

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -38,7 +38,7 @@ defmodule ThousandIsland.Transports.TCP do
 
   alias ThousandIsland.Transport
 
-  @type options() :: [:inet.inet_backend() | :gen_tcp.listen_option()]
+  @type options() :: [:gen_tcp.listen_option()]
 
   @behaviour Transport
 

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -308,14 +308,15 @@ defmodule ThousandIsland.HandlerTest do
     end
 
     test "it should close the connection and call handle_timeout if the global read_timeout is reached waiting for client data" do
-      # Start handle with a global read_timeout of 50ms for all connections
-      {:ok, port} = start_handler(ReadTimeout, read_timeout: 50)
+      # Start handler with a global read_timeout of 50ms for all connections
+      read_timeout = 50
+      {:ok, port} = start_handler(ReadTimeout, read_timeout: read_timeout)
 
       messages =
         capture_log(fn ->
           {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
           :gen_tcp.send(client, "ping")
-          assert :gen_tcp.recv(client, 0, 100) == {:error, :closed}
+          assert :gen_tcp.recv(client, 0, read_timeout * 2) == {:error, :closed}
           Process.sleep(100)
         end)
 


### PR DESCRIPTION
I added the `read_timeout` as mentioned in #15 .

The `read_timeout` is initialized during `ThousandIsland.start_link/1` and defaults to `:infinity`.
If no explicit timeouts are specified (either in the return values of the callbacks for async or as option on `recv/3` for sync calls) the `read_timeout` value is used.

I added tests to check both cases and one test to validate the priority of the timeouts.

I also tweaked the typespecs for the the `transport_options` and `ThousandIsland.start_link/1` a bit.