### PR TITLE
Fix graphical representation of SupervisoinTree in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ graph TD;
   Server(Server: supervisor, rest_for_one)-->Listener;
   Server-->AcceptorPoolSupervisor(AcceptorPoolSupervisor: dynamic supervisor);
   AcceptorPoolSupervisor--1...n-->AcceptorSupervisor(AcceptorSupervisor: supervisor, rest_for_one)
-  AcceptorSupervisor-->Acceptor(Acceptor: task)
   AcceptorSupervisor-->DynamicSupervisor
+  AcceptorSupervisor-->Acceptor(Acceptor: task)
   DynamicSupervisor--1...n-->Handler(Handler: gen_server)
   Server-->ShutdownListener;
 ```


### PR DESCRIPTION
The AcceptorSupervisor starts the DznamicSupervisor vor the connection before the Acceptor task.

```
children = [
      Supervisor.child_spec({DynamicSupervisor, strategy: :one_for_one}, id: :connection_sup),
      {ThousandIsland.Acceptor, {server_pid, self(), config}}
    ]
```

As the strategy is rest for one the order matters.

Changed the order in the mermaid diagram shown in the README
