### PR TITLE
Don't error on timeout

### DIFF
--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -401,6 +401,9 @@ defmodule ThousandIsland.Handler do
           {:close, state} ->
             {:stop, {:shutdown, :local_closed}, {socket, state}}
 
+          {:error, :timeout, state} ->
+            {:stop, {:shutdown, :timeout}, {socket, state}}
+
           {:error, reason, state} ->
             {:stop, reason, {socket, state}}
         end

--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -328,7 +328,7 @@ defmodule ThousandIsland.Handler do
       end
 
       def handle_info(:timeout, {socket, state}) do
-        {:stop, :timeout, {socket, state}}
+        {:stop, {:shutdown, :timeout}, {socket, state}}
       end
 
       @impl GenServer
@@ -342,7 +342,7 @@ defmodule ThousandIsland.Handler do
 
       @impl GenServer
       # Called by GenServer if we hit our read_timeout. Socket is still open
-      def terminate(:timeout, {socket, state}) do
+      def terminate({:shutdown, :timeout}, {socket, state}) do
         __MODULE__.handle_timeout(socket, state)
         do_socket_close(socket, :timeout)
       end

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -362,6 +362,9 @@ defmodule ThousandIsland.HandlerTest do
         Logger.info("ping_received")
 
         case ThousandIsland.Socket.recv(socket, 0) do
+          {:error, :timeout} ->
+            {:error, {:shutdown, :timeout}, state}
+
           {:error, reason} ->
             {:error, reason, state}
 

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -362,9 +362,6 @@ defmodule ThousandIsland.HandlerTest do
         Logger.info("ping_received")
 
         case ThousandIsland.Socket.recv(socket, 0) do
-          {:error, :timeout} ->
-            {:error, {:shutdown, :timeout}, state}
-
           {:error, reason} ->
             {:error, reason, state}
 


### PR DESCRIPTION
Fixes timeout error (like [Bandit#79](https://github.com/mtrudel/bandit/issues/79)).
Since we have `handle_timeout/2` where an error can be logged if necessary, I think we can safely do it like this.