### PR TITLE
Telemetry improvements

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -121,8 +121,6 @@ defmodule ThousandIsland do
   forcibly shutting those connections down at server shutdown time, in milliseconds. Defaults to
   15_000. May also be `:infinity` or `:brutal_kill` as described in the `Supervisor`
   documentation.
-  * `parent_span_id`: The span ID to use as the parent of the top-level `:listener` span for
-  telemetry. Optional.
   """
   @type options :: [
           handler_module: module(),
@@ -133,8 +131,7 @@ defmodule ThousandIsland do
           transport_options: transport_options(),
           num_acceptors: pos_integer(),
           read_timeout: timeout(),
-          shutdown_timeout: timeout(),
-          parent_span_id: String.t()
+          shutdown_timeout: timeout()
         ]
 
   @type transport_options() ::

--- a/lib/thousand_island/listener.ex
+++ b/lib/thousand_island/listener.ex
@@ -20,8 +20,7 @@ defmodule ThousandIsland.Listener do
           local_address: local_info.address,
           local_port: local_info.port,
           transport_module: server_config.transport_module,
-          transport_options: server_config.transport_options,
-          parent_id: server_config.parent_span_id
+          transport_options: server_config.transport_options
         }
 
         span = ThousandIsland.Telemetry.start_span(:listener, %{}, span_meta)

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -11,8 +11,7 @@ defmodule ThousandIsland.ServerConfig do
           genserver_options: GenServer.options(),
           num_acceptors: pos_integer(),
           read_timeout: timeout(),
-          shutdown_timeout: timeout(),
-          parent_span_id: String.t() | nil
+          shutdown_timeout: timeout()
         }
 
   defstruct port: 4000,
@@ -23,8 +22,7 @@ defmodule ThousandIsland.ServerConfig do
             genserver_options: [],
             num_acceptors: 100,
             read_timeout: 60_000,
-            shutdown_timeout: 15_000,
-            parent_span_id: nil
+            shutdown_timeout: 15_000
 
   @spec new(ThousandIsland.options()) :: t()
   def new(opts \\ []) do

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -19,7 +19,6 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following metadata:
 
       * `span_id`: The ID of this span
-      * `parent_id`: The span ID passed to Thousand Island via the `parent_span_id` option
       * `local_address`: The IP address that the listener is bound to
       * `local_port`: The port that the listener is bound to
       * `transport_module`: The transport module in use

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -61,7 +61,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following metadata:
 
       * `telemetry_span_context`: A unique identifier for this span
-      * `telemetry_parent_span_context`: The span context of the `:listener` which created this acceptor
+      * `parent_telemetry_span_context`: The span context of the `:listener` which created this acceptor
 
   This span is ended by the following event:
 
@@ -78,7 +78,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following metadata:
 
       * `telemetry_span_context`: A unique identifier for this span
-      * `telemetry_parent_span_context`: The span context of the `:listener` which created this acceptor
+      * `parent_telemetry_span_context`: The span context of the `:listener` which created this acceptor
       * `error`: The error that caused the span to end, if it ended in error
 
   ## `[:thousand_island, :connection, *]`
@@ -98,7 +98,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following metadata:
 
       * `telemetry_span_context`: A unique identifier for this span
-      * `telemetry_parent_span_context`: The span context of the `:acceptor` span which accepted
+      * `parent_telemetry_span_context`: The span context of the `:acceptor` span which accepted
       this connection
       * `remote_address`: The IP address of the connected client
       * `remote_port`: The port of the connected client
@@ -121,7 +121,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following metadata:
 
       * `telemetry_span_context`: A unique identifier for this span
-      * `telemetry_parent_span_context`: The span context of the `:acceptor` span which accepted
+      * `parent_telemetry_span_context`: The span context of the `:acceptor` span which accepted
       this connection
       * `remote_address`: The IP address of the connected client
       * `remote_port`: The port of the connected client
@@ -276,7 +276,7 @@ defmodule ThousandIsland.Telemetry do
   @spec start_child_span(t(), atom(), map(), map()) :: t()
   def start_child_span(parent_span, span_name, measurements \\ %{}, metadata \\ %{}) do
     metadata =
-      Map.put(metadata, :telemetry_parent_span_context, parent_span.telemetry_span_context)
+      Map.put(metadata, :parent_telemetry_span_context, parent_span.telemetry_span_context)
 
     start_span(span_name, measurements, metadata)
   end

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -122,7 +122,7 @@ defmodule ThousandIsland.Telemetry do
 
       * `telemetry_span_context`: A unique identifier for this span
       * `parent_telemetry_span_context`: The span context of the `:acceptor` span which accepted
-      this connection
+        this connection
       * `remote_address`: The IP address of the connected client
       * `remote_port`: The port of the connected client
       * `error`: The error that caused the span to end, if it ended in error

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -546,6 +546,9 @@ defmodule ThousandIsland.HandlerTest do
 
       {:ok, port} = start_handler(Telemetry.Closer)
 
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      {:ok, {ip, port}} = :inet.sockname(client)
+
       :gen_tcp.connect(:localhost, port, active: false)
       Process.sleep(100)
 
@@ -559,7 +562,13 @@ defmodule ThousandIsland.HandlerTest do
                   recv_oct: 0,
                   send_cnt: 1,
                   send_oct: 5
-                }, %{telemetry_span_context: reference()}}
+                },
+                %{
+                  telemetry_parent_span_context: reference(),
+                  remote_address: ip,
+                  remote_port: port,
+                  telemetry_span_context: reference()
+                }}
              ]
     end
 
@@ -581,7 +590,8 @@ defmodule ThousandIsland.HandlerTest do
 
       {:ok, port} = start_handler(Telemetry.Error)
 
-      :gen_tcp.connect(:localhost, port, active: false)
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      {:ok, {ip, port}} = :inet.sockname(client)
       Process.sleep(100)
 
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
@@ -594,7 +604,14 @@ defmodule ThousandIsland.HandlerTest do
                   recv_oct: 0,
                   send_cnt: 0,
                   send_oct: 0
-                }, %{error: :nope, telemetry_span_context: reference()}}
+                },
+                %{
+                  error: :nope,
+                  telemetry_parent_span_context: reference(),
+                  remote_address: ip,
+                  remote_port: port,
+                  telemetry_span_context: reference()
+                }}
              ]
     end
   end

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -483,7 +483,7 @@ defmodule ThousandIsland.HandlerTest do
              ~> [
                {[:thousand_island, :connection, :start], %{monotonic_time: integer()},
                 %{
-                  telemetry_parent_span_context: reference(),
+                  parent_telemetry_span_context: reference(),
                   remote_address: ip,
                   remote_port: port,
                   telemetry_span_context: reference()
@@ -564,7 +564,7 @@ defmodule ThousandIsland.HandlerTest do
                   send_oct: 5
                 },
                 %{
-                  telemetry_parent_span_context: reference(),
+                  parent_telemetry_span_context: reference(),
                   remote_address: ip,
                   remote_port: port,
                   telemetry_span_context: reference()
@@ -607,7 +607,7 @@ defmodule ThousandIsland.HandlerTest do
                 },
                 %{
                   error: :nope,
-                  telemetry_parent_span_context: reference(),
+                  parent_telemetry_span_context: reference(),
                   remote_address: ip,
                   remote_port: port,
                   telemetry_span_context: reference()

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -481,7 +481,7 @@ defmodule ThousandIsland.HandlerTest do
 
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
              ~> [
-               {[:thousand_island, :connection, :start], %{time: integer()},
+               {[:thousand_island, :connection, :start], %{monotonic_time: integer()},
                 %{
                   parent_id: string(),
                   remote_address: ip,
@@ -504,7 +504,8 @@ defmodule ThousandIsland.HandlerTest do
 
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
              ~> [
-               {[:thousand_island, :connection, :ready], %{time: integer()}, %{span_id: string()}}
+               {[:thousand_island, :connection, :ready], %{monotonic_time: integer()},
+                %{span_id: string()}}
              ]
     end
 
@@ -553,7 +554,7 @@ defmodule ThousandIsland.HandlerTest do
                {[:thousand_island, :connection, :stop],
                 %{
                   duration: integer(),
-                  time: integer(),
+                  monotonic_time: integer(),
                   recv_cnt: 0,
                   recv_oct: 0,
                   send_cnt: 1,
@@ -588,7 +589,7 @@ defmodule ThousandIsland.HandlerTest do
                {[:thousand_island, :connection, :stop],
                 %{
                   duration: integer(),
-                  time: integer(),
+                  monotonic_time: integer(),
                   recv_cnt: 0,
                   recv_oct: 0,
                   send_cnt: 0,

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -483,10 +483,10 @@ defmodule ThousandIsland.HandlerTest do
              ~> [
                {[:thousand_island, :connection, :start], %{monotonic_time: integer()},
                 %{
-                  parent_id: string(),
+                  telemetry_parent_span_context: reference(),
                   remote_address: ip,
                   remote_port: port,
-                  span_id: string()
+                  telemetry_span_context: reference()
                 }}
              ]
     end
@@ -505,7 +505,7 @@ defmodule ThousandIsland.HandlerTest do
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
              ~> [
                {[:thousand_island, :connection, :ready], %{monotonic_time: integer()},
-                %{span_id: string()}}
+                %{telemetry_span_context: reference()}}
              ]
     end
 
@@ -524,7 +524,7 @@ defmodule ThousandIsland.HandlerTest do
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
              ~> [
                {[:thousand_island, :connection, :async_recv], %{data: "ping"},
-                %{span_id: string()}}
+                %{telemetry_span_context: reference()}}
              ]
     end
 
@@ -559,7 +559,7 @@ defmodule ThousandIsland.HandlerTest do
                   recv_oct: 0,
                   send_cnt: 1,
                   send_oct: 5
-                }, %{span_id: string()}}
+                }, %{telemetry_span_context: reference()}}
              ]
     end
 
@@ -594,7 +594,7 @@ defmodule ThousandIsland.HandlerTest do
                   recv_oct: 0,
                   send_cnt: 0,
                   send_oct: 0
-                }, %{error: :nope, span_id: string()}}
+                }, %{error: :nope, telemetry_span_context: reference()}}
              ]
     end
   end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -171,7 +171,7 @@ defmodule ThousandIsland.ServerTest do
 
       assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
              ~> [
-               {[:thousand_island, :listener, :start], %{time: integer()},
+               {[:thousand_island, :listener, :start], %{monotonic_time: integer()},
                 %{
                   span_id: string(),
                   parent_id: "PARENTSPAN",
@@ -180,12 +180,13 @@ defmodule ThousandIsland.ServerTest do
                   transport_module: ThousandIsland.Transports.TCP,
                   transport_options: []
                 }},
-               {[:thousand_island, :acceptor, :start], %{time: integer()},
+               {[:thousand_island, :acceptor, :start], %{monotonic_time: integer()},
                 %{parent_id: string(), span_id: string()}},
-               {[:thousand_island, :listener, :stop], %{duration: integer(), time: integer()},
-                %{span_id: string()}},
+               {[:thousand_island, :listener, :stop],
+                %{duration: integer(), monotonic_time: integer()}, %{span_id: string()}},
                {[:thousand_island, :acceptor, :stop],
-                %{connections: 0, duration: integer(), time: integer()}, %{span_id: string()}}
+                %{connections: 0, duration: integer(), monotonic_time: integer()},
+                %{span_id: string()}}
              ]
     end
   end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -180,7 +180,7 @@ defmodule ThousandIsland.ServerTest do
                   transport_options: []
                 }},
                {[:thousand_island, :acceptor, :start], %{monotonic_time: integer()},
-                %{telemetry_span_context: reference(), telemetry_parent_span_context: reference()}},
+                %{telemetry_span_context: reference(), parent_telemetry_span_context: reference()}},
                {[:thousand_island, :listener, :stop],
                 %{duration: integer(), monotonic_time: integer()},
                 %{
@@ -192,7 +192,7 @@ defmodule ThousandIsland.ServerTest do
                 }},
                {[:thousand_island, :acceptor, :stop],
                 %{connections: 0, duration: integer(), monotonic_time: integer()},
-                %{telemetry_span_context: reference(), telemetry_parent_span_context: reference()}}
+                %{telemetry_span_context: reference(), parent_telemetry_span_context: reference()}}
              ]
     end
   end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -183,10 +183,16 @@ defmodule ThousandIsland.ServerTest do
                 %{telemetry_span_context: reference(), telemetry_parent_span_context: reference()}},
                {[:thousand_island, :listener, :stop],
                 %{duration: integer(), monotonic_time: integer()},
-                %{telemetry_span_context: reference()}},
+                %{
+                  telemetry_span_context: reference(),
+                  local_address: {0, 0, 0, 0},
+                  local_port: integer(),
+                  transport_module: ThousandIsland.Transports.TCP,
+                  transport_options: []
+                }},
                {[:thousand_island, :acceptor, :stop],
                 %{connections: 0, duration: integer(), monotonic_time: integer()},
-                %{telemetry_span_context: reference()}}
+                %{telemetry_span_context: reference(), telemetry_parent_span_context: reference()}}
              ]
     end
   end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -165,7 +165,7 @@ defmodule ThousandIsland.ServerTest do
            ]}
         )
 
-      {:ok, server_pid, _} = start_handler(Echo, num_acceptors: 1, parent_span_id: "PARENTSPAN")
+      {:ok, server_pid, _} = start_handler(Echo, num_acceptors: 1)
 
       ThousandIsland.stop(server_pid)
 
@@ -174,7 +174,6 @@ defmodule ThousandIsland.ServerTest do
                {[:thousand_island, :listener, :start], %{monotonic_time: integer()},
                 %{
                   span_id: string(),
-                  parent_id: "PARENTSPAN",
                   local_address: {0, 0, 0, 0},
                   local_port: integer(),
                   transport_module: ThousandIsland.Transports.TCP,

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -173,19 +173,20 @@ defmodule ThousandIsland.ServerTest do
              ~> [
                {[:thousand_island, :listener, :start], %{monotonic_time: integer()},
                 %{
-                  span_id: string(),
+                  telemetry_span_context: reference(),
                   local_address: {0, 0, 0, 0},
                   local_port: integer(),
                   transport_module: ThousandIsland.Transports.TCP,
                   transport_options: []
                 }},
                {[:thousand_island, :acceptor, :start], %{monotonic_time: integer()},
-                %{parent_id: string(), span_id: string()}},
+                %{telemetry_span_context: reference(), telemetry_parent_span_context: reference()}},
                {[:thousand_island, :listener, :stop],
-                %{duration: integer(), monotonic_time: integer()}, %{span_id: string()}},
+                %{duration: integer(), monotonic_time: integer()},
+                %{telemetry_span_context: reference()}},
                {[:thousand_island, :acceptor, :stop],
                 %{connections: 0, duration: integer(), monotonic_time: integer()},
-                %{span_id: string()}}
+                %{telemetry_span_context: reference()}}
              ]
     end
   end

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -126,8 +126,10 @@ defmodule ThousandIsland.SocketTest do
 
         assert ThousandIsland.TelemetryCollector.get_events(collector_pid)
                ~> [
-                 {[:thousand_island, :connection, :recv], %{data: "HELLO"}, %{span_id: string()}},
-                 {[:thousand_island, :connection, :send], %{data: "HELLO"}, %{span_id: string()}}
+                 {[:thousand_island, :connection, :recv], %{data: "HELLO"},
+                  %{telemetry_span_context: reference()}},
+                 {[:thousand_island, :connection, :send], %{data: "HELLO"},
+                  %{telemetry_span_context: reference()}}
                ]
       end
     end


### PR DESCRIPTION
Satisfies the Thousand Island part of https://github.com/mtrudel/bandit/issues/105. 

* Replace `time` with `monotonic_time`
* Replace `span_id` with `telemetry_span_context`
* Replace `parent_span_id` with `parent_telemetry_span_context`
* Add all start metadata to stop metadata