### PR TITLE
Config cleanup

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -96,25 +96,25 @@ defmodule ThousandIsland do
   Possible options to configure a server. Valid option values are as follows:
 
   * `handler_module`: The name of the module used to handle connections to this server.
-  The module is expected to implement the `ThousandIsland.Handler` behaviour. Required.
+  The module is expected to implement the `ThousandIsland.Handler` behaviour. Required
   * `handler_options`: A term which is passed as the initial state value to
   `c:ThousandIsland.Handler.handle_connection/2` calls. Optional, defaulting to nil.
   * `genserver_options`: A term which is passed as the value to the handler module's
-  underlying `GenServer.start_link/3` call. Optional, defaulting to [].
+  underlying `GenServer.start_link/3` call. Optional, defaulting to []
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
-  which can then be obtained via `local_info/1`.
+  which can then be obtained via `local_info/1`
   * `transport_module`: The name of the module which provides basic socket functions.
   Thousand Island provides `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL`,
   which provide clear and TLS encrypted TCP sockets respectively. If not specified this
-  defaults to `ThousandIsland.Transports.TCP`.
+  defaults to `ThousandIsland.Transports.TCP`
   * `transport_options`: A keyword list of options to be passed to the transport module's
   `c:ThousandIsland.Transport.listen/2` function. Valid values depend on the transport
   module specified in `transport_module` and can be found in the documentation for the
   `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL` modules. Any options
   in terms of interfaces to listen to / certificates and keys to use for SSL connections
-  will be passed in via this option.
-  * `num_acceptors`: The number of acceptor processes to run. Defaults to 100.
+  will be passed in via this option
+  * `num_acceptors`: The number of acceptor processes to run. Defaults to 100
   * `num_connections`: The maximum number of concurrent connections which each acceptor will
   accept before throttling connections. Connections will be throttled by having the acceptor
   process wait `max_connections_retry_wait` milliseconds, up to `max_connections_retry_count`
@@ -124,15 +124,15 @@ defmodule ThousandIsland do
   is expressed per-acceptor, so the total number of maximum connections for a Thousand Island
   server is `num_acceptors * num_connections`. Defaults to `:infinity`.
   * `max_connections_retry_wait`: How long to wait during each iteration as described in
-  `num_connectors` above, in milliseconds. Defaults to `1000`.
+  `num_connectors` above, in milliseconds. Defaults to `1000`
   * `max_connections_retry_count`: How many iterations to wait as described in `num_connectors`
-  above. Defaults to `5`.
+  above. Defaults to `5`
   * `read_timeout`: How long to wait for client data before closing the connection, in
-  milliseconds. Defaults to 60_000.
+  milliseconds. Defaults to 60_000
   * `shutdown_timeout`: How long to wait for existing client connections to complete before
   forcibly shutting those connections down at server shutdown time, in milliseconds. Defaults to
   15_000. May also be `:infinity` or `:brutal_kill` as described in the `Supervisor`
-  documentation.
+  documentation
   """
   @type options :: [
           handler_module: module(),

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -156,7 +156,7 @@ defmodule ThousandIsland do
   @spec child_spec(options()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
-      id: __MODULE__,
+      id: {__MODULE__, make_ref()},
       start: {__MODULE__, :start_link, [opts]},
       type: :supervisor,
       restart: :permanent

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -122,7 +122,7 @@ defmodule ThousandIsland do
   still no room for this new connection after this interval, the acceptor will close the client
   connection and emit a `[:thousand_island, :acceptor, :spawn_error]` telemetry event. This number
   is expressed per-acceptor, so the total number of maximum connections for a Thousand Island
-  server is `num_acceptors * num_connections`. Defaults to `:infinity`.
+  server is `num_acceptors * num_connections`. Defaults to `16_384`
   * `max_connections_retry_wait`: How long to wait during each iteration as described in
   `num_connectors` above, in milliseconds. Defaults to `1000`
   * `max_connections_retry_count`: How many iterations to wait as described in `num_connectors`

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -24,7 +24,7 @@ defmodule ThousandIsland.ServerConfig do
             handler_options: [],
             genserver_options: [],
             num_acceptors: 100,
-            num_connections: :infinity,
+            num_connections: 16_384,
             max_connections_retry_count: 5,
             max_connections_retry_wait: 1000,
             read_timeout: 60_000,

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -5,19 +5,18 @@ defmodule ThousandIsland.Transports.SSL do
   Island will only ever need to deal with this module via `transport_options`
   passed to `ThousandIsland` at startup time. A complete list of such options
   is defined via the `t::ssl.tls_server_option` type. This list can be somewhat
-  difficult to decipher; a list of the most common options follows:
+  difficult to decipher; by far the most common values to pass to this transport
+  are the following:
 
-  * `key`: A DER encoded binary representation of the SSL key to use
-  * `cert`: A DER encoded binary representation of the SSL key to use
-  * `keyfile`: A string path to a PEM encoded key to use for SSL
-  * `certfile`: A string path to a PEM encoded cert to use for SSL
-  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be
-  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can
-  be used to only bind to localhost. On platforms which support it (macOS and
-  Linux at a minimum, likely others), you can also bind to a Unix domain socket
-  by specifying a value of `ip: {:local, "/path/to/socket"}`. Note that the port
-  *must* be set to `0`, and that the socket is not removed from the filesystem
-  after the server shuts down.
+  * `keyfile`: An absolute string path to a PEM encoded key to use for SSL
+  * `certfile`: An absolute string path to a PEM encoded cert to use for SSL
+  * `ip`:  The IP to listen on. Can be specified as:
+    * `{1, 2, 3, 4}` for IPv4 addresses
+    * `{1, 2, 3, 4, 5, 6, 7, 8}` for IPv6 addresses
+    * `:loopback` for local loopback
+    * `:any` for all interfaces (ie: `0.0.0.0`)
+    * `{:local, "/path/to/socket"}` for a Unix domain socket. If this option is used, the `port`
+    option *must* be set to `0`.
 
   Unless overridden, this module uses the following default options:
 
@@ -31,7 +30,7 @@ defmodule ThousandIsland.Transports.SSL do
   ```
 
   The following options are required for the proper operation of Thousand Island
-  and cannot be overridden at startup (though they can be set via calls to `setopts/2`)
+  and cannot be overridden:
 
   ```elixir
   mode: :binary,

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -8,13 +8,13 @@ defmodule ThousandIsland.Transports.TCP do
   difficult to decipher; by far the most common value to pass to this transport
   is the following:
 
-  * `ip`:  The IP to listen on (defaults to all interfaces). IPs should be
-  described in tuple form (ie: `ip: {1, 2, 3, 4}`). The value `:loopback` can
-  be used to only bind to localhost. On platforms which support it (macOS and
-  Linux at a minimum, likely others), you can also bind to a Unix domain socket
-  by specifying a value of `ip: {:local, "/path/to/socket"}`. Note that the port
-  *must* be set to `0`, and that the socket is not removed from the filesystem
-  after the server shuts down.
+  * `ip`:  The IP to listen on. Can be specified as:
+    * `{1, 2, 3, 4}` for IPv4 addresses
+    * `{1, 2, 3, 4, 5, 6, 7, 8}` for IPv6 addresses
+    * `:loopback` for local loopback
+    * `:any` for all interfaces (ie: `0.0.0.0`)
+    * `{:local, "/path/to/socket"}` for a Unix domain socket. If this option is used, the `port`
+    option *must* be set to `0`.
 
   Unless overridden, this module uses the following default options:
 
@@ -28,7 +28,7 @@ defmodule ThousandIsland.Transports.TCP do
   ```
 
   The following options are required for the proper operation of Thousand Island
-  and cannot be overridden at startup (though they can be set via calls to `setopts/2`)
+  and cannot be overridden:
 
   ```elixir
   mode: :binary,


### PR DESCRIPTION
* Use a `{ThousandIsland, ref()}` tuple for id
* Set `num_connections` to 16384 by default
* Update docs 