### PR TITLE
Refines types for Transport behaviour, TCP, and SSL implementations

### DIFF
--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -12,9 +12,13 @@ defmodule ThousandIsland.Transports.TCP do
     * `{1, 2, 3, 4}` for IPv4 addresses
     * `{1, 2, 3, 4, 5, 6, 7, 8}` for IPv6 addresses
     * `:loopback` for local loopback
-    * `:any` for all interfaces (ie: `0.0.0.0`)
-    * `{:local, "/path/to/socket"}` for a Unix domain socket. If this option is used, the `port`
-      option *must* be set to `0`.
+    * `:any` for all interfaces (i.e.: `0.0.0.0`)
+    * `{:local, "/path/to/socket"}` for a Unix domain socket. If this option is used,
+      the `port` option *must* be set to `0`
+    * `:unspec` family corresponds to AF_UNSPEC and can occur if the other side has
+      no socket address
+    * `{:undefined, any_term}` family can only occur in the unlikely event of an address
+      family that the VM does not recognise.
 
   Unless overridden, this module uses the following default options:
 
@@ -37,12 +41,17 @@ defmodule ThousandIsland.Transports.TCP do
   """
 
   @type options() :: [:gen_tcp.listen_option()]
+  @typep listener_socket :: :inet.socket()
+  @typep socket() :: :inet.socket()
 
   @behaviour ThousandIsland.Transport
 
   @hardcoded_options [mode: :binary, active: false]
 
   @impl ThousandIsland.Transport
+  @spec listen(:inet.port_number(), keyword()) ::
+          {:ok, listener_socket()} | {:error, reason}
+        when reason: :system_limit | :inet.posix()
   def listen(port, user_options) do
     default_options = [
       backlog: 1024,
@@ -58,21 +67,38 @@ defmodule ThousandIsland.Transports.TCP do
   end
 
   @impl ThousandIsland.Transport
+  @spec accept(listener_socket()) ::
+          {:ok, socket()} | {:error, reason}
+        when reason: :closed | :system_limit | :inet.posix()
   defdelegate accept(listener_socket), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec handshake(socket()) :: {:ok, socket()}
   def handshake(socket), do: {:ok, socket}
 
   @impl ThousandIsland.Transport
+  @spec controlling_process(socket(), pid()) :: :ok | {:error, reason}
+        when reason: :closed | :not_owner | :badarg | :inet.posix()
   defdelegate controlling_process(socket, pid), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec recv(socket(), non_neg_integer(), timeout()) :: {:ok, binary()} | {:error, reason}
+        when reason: :closed | :timeout | :inet.posix()
   defdelegate recv(socket, length, timeout), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec send(socket(), iodata()) :: :ok | {:error, reason}
+        when reason: :closed | {:timeout, rest_data :: binary()} | :inet.posix()
   defdelegate send(socket, data), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec sendfile(
+          socket(),
+          filename :: String.t(),
+          offset :: non_neg_integer(),
+          length :: non_neg_integer()
+        ) :: {:ok, non_neg_integer()} | {:error, reason}
+        when reason: :inet.posix() | :closed | :badarg | :not_owner
   def sendfile(socket, filename, offset, length) do
     with {:ok, fd} <- :file.open(filename, [:raw]) do
       :file.sendfile(fd, socket, offset, length, [])
@@ -80,38 +106,66 @@ defmodule ThousandIsland.Transports.TCP do
   end
 
   @impl ThousandIsland.Transport
+  @spec getopts(socket(), ThousandIsland.Transport.socket_get_options()) ::
+          {:ok, [:inet.socket_optval()]} | {:error, :inet.posix()}
   defdelegate getopts(socket, options), to: :inet
 
   @impl ThousandIsland.Transport
+  @spec setopts(socket(), ThousandIsland.Transport.socket_set_options()) ::
+          :ok | {:error, :inet.posix()}
   defdelegate setopts(socket, options), to: :inet
 
   @impl ThousandIsland.Transport
+  @spec shutdown(socket(), ThousandIsland.Transport.way()) :: :ok | {:error, :inet.posix()}
   defdelegate shutdown(socket, way), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec close(socket()) :: :ok
   defdelegate close(socket), to: :gen_tcp
 
   @impl ThousandIsland.Transport
+  @spec local_info(socket()) :: ThousandIsland.Transport.socket_info() | {:error, :inet.posix()}
   def local_info(socket) do
     case :inet.sockname(socket) do
-      {:ok, {:local, path}} -> %{address: {:local, path}, port: 0, ssl_cert: nil}
-      {:ok, {ip, port}} -> %{address: ip, port: port, ssl_cert: nil}
-      other -> other
+      {:ok, spec} ->
+        case spec do
+          {:local, path} -> %{address: {:local, path}, port: 0, ssl_cert: nil}
+          {:unspec, <<>>} -> %{address: :unspec, port: 0, ssl_cert: nil}
+          {:undefined, term} -> %{address: {:undefined, term}, port: 0, ssl_cert: nil}
+          {ip, port} -> %{address: ip, port: port, ssl_cert: nil}
+        end
+
+      err ->
+        err
     end
   end
 
   @impl ThousandIsland.Transport
+  @spec peer_info(socket()) :: ThousandIsland.Transport.socket_info() | {:error, :inet.posix()}
   def peer_info(socket) do
-    {:ok, {ip, port}} = :inet.peername(socket)
-    %{address: ip, port: port, ssl_cert: nil}
+    case :inet.peername(socket) do
+      {:ok, spec} ->
+        case spec do
+          {:local, path} -> %{address: {:local, path}, port: 0, ssl_cert: nil}
+          {:unspec, <<>>} -> %{address: :unspec, port: 0, ssl_cert: nil}
+          {:undefined, term} -> %{address: {:undefined, term}, port: 0, ssl_cert: nil}
+          {ip, port} -> %{address: ip, port: port, ssl_cert: nil}
+        end
+
+      err ->
+        err
+    end
   end
 
   @impl ThousandIsland.Transport
+  @spec secure?() :: false
   def secure?, do: false
 
   @impl ThousandIsland.Transport
+  @spec getstat(socket()) :: ThousandIsland.Transport.socket_stats()
   defdelegate getstat(socket), to: :inet
 
   @impl ThousandIsland.Transport
+  @spec negotiated_protocol(socket()) :: {:error, :protocol_not_negotiated}
   def negotiated_protocol(_socket), do: {:error, :protocol_not_negotiated}
 end


### PR DESCRIPTION
It turns out that some callbacks actually should have a broader union type, than they have at the moment. In many cases that's because of missing error tuple. But there are a few worth mentioning:
* `@type on_handshake()` needs to be extended with `{:ok, socket(), any()}` because `:ssl.handshake/1` might return it (but TCP.handshake/1 always returns `{:ok, socket()}`)
* `@callback peer_info/1` `{:error, :inet.posix()}` because both implementations uses the same function from `:inet` module.

At the moment `Transport` defines callbacks with really generic types mostly to fulfill more specific types defined in transport implementation modules. I don't really know what would be the best industry practice to apply here, so let me know please.

Note about `:ssl` modules: dialyzer cannot look over indirect calls  and that reduces greatly it ability to infer types. ':ssl` is wrapper around `:tls_socket` and `:dtls_socket` which uses `:gen_tcp` and `:gen_udp` as a transport. So I would expect that functions in `:ssl` would have similar types, but they haven't. Feels like limitation of the current language model to me.

Regarding `@type socket_info`: since the user has a control over what options to pass to sockets, it might be that  `:inet.peername/1` and `:inet.sockname/1` return some special values like `{:unspec, <<>>}` or `{:undefined, any()}`. I had to handle them in order to prevent dialyzer of inferring really weird types.