### PR TITLE
handle econnaborted error from OS kernel

### DIFF
--- a/lib/thousand_island/acceptor.ex
+++ b/lib/thousand_island/acceptor.ex
@@ -29,7 +29,7 @@ defmodule ThousandIsland.Acceptor do
       {:error, :too_many_connections} ->
         ThousandIsland.Telemetry.span_event(span, :spawn_error)
 
-      {:error, reason} when reason in [:closed, :einval] ->
+      {:error, reason} when reason in [:closed, :einval, :econnaborted] ->
         ThousandIsland.Telemetry.stop_span(span, %{connections: count})
 
       {:error, reason} ->


### PR DESCRIPTION
Per chat, these errors are raised when the kernel has terminated a connection,
with prejudice, for example during SSL weakness probing, incomplete 3-way TCP,
handshakes or similar.

It's not possible to get info about the remote socket, to log info, as it's
no longer available from the kernel.

This raised more questions than I'd anticipated, as I'm not really a Telemetry
user yet. Do we need to close the span, per the catch-all handler, or is
it sufficient to emit an event?
