### PR TITLE
Fix typo in port option docs

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -104,7 +104,7 @@ defmodule ThousandIsland do
   underlying `GenServer.start_link/3` call. Optional, defaulting to []
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
-  which can then be obtained via `sockname/1`
+  which can then be obtained via `listener_info/1`
   * `transport_module`: The name of the module which provides basic socket functions.
   Thousand Island provides `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL`,
   which provide clear and TLS encrypted TCP sockets respectively. If not specified this

--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -104,7 +104,8 @@ defmodule ThousandIsland do
   underlying `GenServer.start_link/3` call. Optional, defaulting to []
   * `port`: The TCP port number to listen on. If not specified this defaults to 4000.
   If a port number of `0` is given, the server will dynamically assign a port number
-  which can then be obtained via `listener_info/1`
+  which can then be obtained via `ThousandIsland.listener_info/1` or
+  `ThousandIsland.Socket.sockname/1`
   * `transport_module`: The name of the module which provides basic socket functions.
   Thousand Island provides `ThousandIsland.Transports.TCP` and `ThousandIsland.Transports.SSL`,
   which provide clear and TLS encrypted TCP sockets respectively. If not specified this


### PR DESCRIPTION
It seems like this is supposed to be `listener_info/1`.