### PR TITLE
Rely on default `files` list for hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,6 @@ defmodule ThousandIsland.MixProject do
       description: "A simple & modern pure Elixir socket server",
       source_url: "https://github.com/mtrudel/thousand_island",
       package: [
-        files: ["lib", "test", "mix.exs", "README*", "LICENSE*"],
         maintainers: ["Mat Trudel"],
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/mtrudel/thousand_island"}


### PR DESCRIPTION
The initial goal for this change was to incorporate the CHANGELOG into the hex package so that it would be available in the diff tool on hex.pm or the command line (i.e. `mix hex.package diff thousand_island 1.1.0..1.2.0`).

Per discussion in mtrudel/bandit#265 we'll accomplish the above by removing the `files` configuration and relying on the default list of files provided by hex (see the linked issue for details).

This change will also have the effect of removing test files from future releases.