### PR TITLE
Do not set SO_LINGER by default

### DIFF
--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -23,7 +23,6 @@ defmodule ThousandIsland.Transports.SSL do
   ```elixir
   backlog: 1024,
   nodelay: true,
-  linger: {true, 30},
   send_timeout: 30_000,
   send_timeout_close: true,
   reuseaddr: true
@@ -53,7 +52,6 @@ defmodule ThousandIsland.Transports.SSL do
     default_options = [
       backlog: 1024,
       nodelay: true,
-      linger: {true, 30},
       send_timeout: 30_000,
       send_timeout_close: true,
       reuseaddr: true

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -21,7 +21,6 @@ defmodule ThousandIsland.Transports.TCP do
   ```elixir
   backlog: 1024,
   nodelay: true,
-  linger: {true, 30},
   send_timeout: 30_000,
   send_timeout_close: true,
   reuseaddr: true
@@ -51,7 +50,6 @@ defmodule ThousandIsland.Transports.TCP do
     default_options = [
       backlog: 1024,
       nodelay: true,
-      linger: {true, 30},
       send_timeout: 30_000,
       send_timeout_close: true,
       reuseaddr: true


### PR DESCRIPTION
This should fix a number of 'freeze' related issues on larger instances, particularly those behind network layer load balancers. 

The origin of setting `SO_LINGER` dates *way* back to the earliest days of Thousand Island, and the original reasoning for it is lost to the ages. We're in good company by removing it though; it's an odd choice for a socket library and eg. ranch doesn't set it by default either. 

