### PR TITLE
Fix config options merging

### DIFF
--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -57,7 +57,10 @@ defmodule ThousandIsland.Transports.SSL do
       reuseaddr: true
     ]
 
-    resolved_options = @hardcoded_options ++ user_options ++ default_options
+    resolved_options =
+      default_options
+      |> Keyword.merge(user_options)
+      |> Keyword.merge(@hardcoded_options)
 
     if not Enum.any?(
          [:keyfile, :key, :sni_hosts, :sni_fun],

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -55,7 +55,11 @@ defmodule ThousandIsland.Transports.TCP do
       reuseaddr: true
     ]
 
-    resolved_options = @hardcoded_options ++ user_options ++ default_options
+    resolved_options =
+      default_options
+      |> Keyword.merge(user_options)
+      |> Keyword.merge(@hardcoded_options)
+
     :gen_tcp.listen(port, resolved_options)
   end
 

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -204,7 +204,7 @@ defmodule ThousandIsland.ServerTest do
     assert {:ok, []} == ThousandIsland.connection_pids(server_pid)
   end
 
-  describe "suspend / reume" do
+  describe "suspend / resume" do
     test "suspend should stop accepting connections but keep existing ones open" do
       {:ok, server_pid, port} = start_handler(LongEcho, port: 9999)
       {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
@@ -367,20 +367,16 @@ defmodule ThousandIsland.ServerTest do
   describe "invalid configuration" do
     @tag capture_log: true
     test "it should error if a certificate is not found" do
-      server_args = [
-        port: 0,
-        handler_module: Error,
-        handler_options: [test_pid: self()],
-        transport_module: ThousandIsland.Transports.SSL,
-        transport_options: [
-          certfile: Path.join(__DIR__, "./not/a/cert.pem"),
-          keyfile: Path.join(__DIR__, "./not/a/key.pem"),
-          alpn_preferred_protocols: ["foo"]
-        ]
-      ]
-
-      {:ok, server_pid} = start_supervised({ThousandIsland, server_args})
-      {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+      {:ok, server_pid, port} =
+        start_handler(Error,
+          handler_options: [test_pid: self()],
+          transport_module: ThousandIsland.Transports.SSL,
+          transport_options: [
+            certfile: Path.join(__DIR__, "./not/a/cert.pem"),
+            keyfile: Path.join(__DIR__, "./not/a/key.pem"),
+            alpn_preferred_protocols: ["foo"]
+          ]
+        )
 
       {:error, _} =
         :ssl.connect(~c"localhost", port,


### PR DESCRIPTION
Currently the `user_options` could overwrite the `@hardcoded_options` but not the `default_options` (`gen_tcp` seems to take the last option if multiple values for 1 key are defined).

This fixes the problem by allowing the `user_options` to overwrite the `default_options` and applying the `@hardcoded_options` last.