### PR TITLE
Use bare list concatenation to allow non keyword options

### DIFF
--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -57,10 +57,11 @@ defmodule ThousandIsland.Transports.SSL do
       reuseaddr: true
     ]
 
+    # We can't use Keyword functions here because :ssl accepts non-keyword style options
     resolved_options =
-      default_options
-      |> Keyword.merge(user_options)
-      |> Keyword.merge(@hardcoded_options)
+      default_options ++
+        user_options ++
+        @hardcoded_options
 
     if not Enum.any?(
          [:keyfile, :key, :sni_hosts, :sni_fun],

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -55,10 +55,11 @@ defmodule ThousandIsland.Transports.TCP do
       reuseaddr: true
     ]
 
+    # We can't use Keyword functions here because :gen_tcp accepts non-keyword style options
     resolved_options =
-      default_options
-      |> Keyword.merge(user_options)
-      |> Keyword.merge(@hardcoded_options)
+      default_options ++
+        user_options ++
+        @hardcoded_options
 
     :gen_tcp.listen(port, resolved_options)
   end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -390,6 +390,13 @@ defmodule ThousandIsland.ServerTest do
       {:ok, ~c"{:ok, [mode: :binary]}"} = :gen_tcp.recv(client, 0, 100)
     end
 
+    test "tcp should allow Erlang style bare options" do
+      {:ok, _, port} = start_handler(Echo, transport_options: [:inet6])
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      :gen_tcp.send(client, "HI")
+      {:ok, ~c"HI"} = :gen_tcp.recv(client, 0, 100)
+    end
+
     test "ssl should allow default options to be overridden" do
       {:ok, _, port} =
         start_handler(ReadOpt,
@@ -432,6 +439,29 @@ defmodule ThousandIsland.ServerTest do
 
       :ssl.send(client, "mode")
       {:ok, ~c"{:ok, [mode: :binary]}"} = :ssl.recv(client, 0, 100)
+    end
+
+    test "ssl should allow Erlang style bare options" do
+      {:ok, _, port} =
+        start_handler(Echo,
+          transport_module: ThousandIsland.Transports.SSL,
+          transport_options:
+            [:inet6] ++
+              [
+                certfile: Path.join(__DIR__, "../support/cert.pem"),
+                keyfile: Path.join(__DIR__, "../support/key.pem")
+              ]
+        )
+
+      {:ok, client} =
+        :ssl.connect(:localhost, port,
+          active: false,
+          verify: :verify_none,
+          cacertfile: Path.join(__DIR__, "../support/ca.pem")
+        )
+
+      :ssl.send(client, "HI")
+      {:ok, ~c"HI"} = :ssl.recv(client, 0, 100)
     end
   end
 


### PR DESCRIPTION
Fixup regression introduced in #111 