### PR TITLE
Support TLS config to use the recently added `certs_keys`

### DIFF
--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -68,14 +68,14 @@ defmodule ThousandIsland.Transports.SSL do
       )
 
     if not Enum.any?(
-         [:keyfile, :key, :sni_hosts, :sni_fun],
+         [:certs_keys, :keyfile, :key, :sni_hosts, :sni_fun],
          &:proplists.is_defined(&1, resolved_options)
        ) do
       raise "transport_options must include one of keyfile, key, sni_hosts or sni_fun"
     end
 
     if not Enum.any?(
-         [:certfile, :cert, :sni_hosts, :sni_fun],
+         [:certs_keys, :certfile, :cert, :sni_hosts, :sni_fun],
          &:proplists.is_defined(&1, resolved_options)
        ) do
       raise "transport_options must include one of certfile, cert, sni_hosts or sni_fun"


### PR DESCRIPTION
This is one part of Phoenix + Bandit supporting the recently(ish) added `certs_keys` config key for the Erlang SSL stack.

https://www.erlang.org/doc/apps/ssl/ssl.html#t:cert_key_conf/0