### PR TITLE
fix: support `inet_backend` transport option

### DIFF
--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -64,11 +64,13 @@ defmodule ThousandIsland.Transports.TCP do
           key when is_atom(key) -> key
         end
       )
+
     # `inet_backend`, if present, needs to be the first option
-    sorted_options = Enum.sort(resolved_options, fn
-      _, {:inet_backend, _} -> false
-      _, _ -> :true
-    end)
+    sorted_options =
+      Enum.sort(resolved_options, fn
+        _, {:inet_backend, _} -> false
+        _, _ -> true
+      end)
 
     :gen_tcp.listen(port, sorted_options)
   end

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -64,8 +64,13 @@ defmodule ThousandIsland.Transports.TCP do
           key when is_atom(key) -> key
         end
       )
+    # `inet_backend`, if present, needs to be the first option
+    sorted_options = Enum.sort(resolved_options, fn
+      _, {:inet_backend, _} -> false
+      _, _ -> :true
+    end)
 
-    :gen_tcp.listen(port, resolved_options)
+    :gen_tcp.listen(port, sorted_options)
   end
 
   @impl ThousandIsland.Transport

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -410,6 +410,13 @@ defmodule ThousandIsland.ServerTest do
       {:ok, ~c"HI"} = :gen_tcp.recv(client, 0, 100)
     end
 
+    test "tcp should allow inet_backend option" do
+      {:ok, _, port} = start_handler(Echo, transport_options: [inet_backend: :socket])
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      :gen_tcp.send(client, "HI")
+      {:ok, ~c"HI"} = :gen_tcp.recv(client, 0, 100)
+    end
+
     test "ssl should allow default options to be overridden" do
       {:ok, _, port} =
         start_handler(ReadOpt,


### PR DESCRIPTION
While this was available in the spec, it wasn't possible to use. `inet_backend` needs to be the first option, and with the `@hardcoded_options` first that was never possible.