### PR TITLE
Add hexdocs changelog configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,10 @@ defmodule ThousandIsland.MixProject do
       package: [
         maintainers: ["Mat Trudel"],
         licenses: ["MIT"],
-        links: %{"GitHub" => "https://github.com/mtrudel/thousand_island"},
+        links: %{
+          "GitHub" => "https://github.com/mtrudel/thousand_island",
+          "Changelog" => "https://hexdocs.pm/thousand_island/changelog.html"
+        },
         files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"]
       ],
       docs: docs()
@@ -61,6 +64,10 @@ defmodule ThousandIsland.MixProject do
     [
       main: "ThousandIsland",
       logo: "assets/ex_doc_logo.png",
+      extras: ["CHANGELOG.md"],
+      groups_for_extras: [
+        Changelog: ~r/CHANGELOG\.md/
+      ],
       groups_for_modules: [
         Transport: [
           ThousandIsland.Transport,


### PR DESCRIPTION
## Summary
• Configures ex_doc to generate changelog from CHANGELOG.md
• Adds changelog link to package metadata for easier access from hexdocs