### PR TITLE
Separate out network timeout timer from GenServer message timer

### DIFF
--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -22,9 +22,7 @@ defmodule ThousandIsland.Handler do
   application as needed. The implementation included in the `use ThousandIsland.Handler` macro uses a `GenServer` structure,
   so you may implement such behaviour via standard `GenServer` patterns. Note that in these cases that state is provided (and
   must be returned) in a `{socket, state}` format, where the second tuple is the same state value that is passed to the various `handle_*` callbacks
-  defined on this behaviour. It also critical to maintain the socket's `read_timeout` value by
-  ensuring the relevant timeout value is returned as your callback's final argument. Both of these
-  concerns are illustrated in the following example:
+  defined on this behaviour. This is illustrated in the following example:
 
       ```elixir
       defmodule ExampleHandler do
@@ -35,25 +33,36 @@ defmodule ThousandIsland.Handler do
         @impl GenServer
         def handle_call(msg, from, {socket, state}) do
           # Do whatever you'd like with msg & from
-          {:reply, :ok, {socket, state}, socket.read_timeout}
+          {:reply, :ok, {socket, state}}
         end
 
         @impl GenServer
         def handle_cast(msg, {socket, state}) do
           # Do whatever you'd like with msg
-          {:noreply, {socket, state}, socket.read_timeout}
+          {:noreply, {socket, state}}
         end
 
         @impl GenServer
         def handle_info(msg, {socket, state}) do
           # Do whatever you'd like with msg
-          {:noreply, {socket, state}, socket.read_timeout}
+          {:noreply, {socket, state}}
         end
       end
       ```
 
+  Note that previous versions of Thousand Island required you to return the value of
+  socket.read_timeout as the third element in the callback tuple. As of Thousand Island 1.5.0,
+  network-related timeouts are handled entirely internally and as such this option retains its
+  OTP-native semantic of representing an option timeout between *any* message received by this
+  Handler, either network or local. In short, unless you specifically care about timeouts between
+  local mailbox messages, you can safely omit a timeout from your return tuples and the network
+  facing aspects of Thousand Island will continue to have correct timeout behaviour.
+
   It is fully supported to intermix synchronous `ThousandIsland.Socket.recv` calls with async return values from `c:handle_connection/2`
-  and `c:handle_data/3` callbacks.
+  and `c:handle_data/3` callbacks, however it is critical to note that the timeouts between the two
+  are completely separate. The `read_timeout` parameter only applies to reads
+  as observed by `handle_data/3` callbacks, and only applies to the duration *between*
+  ThousandIsland.Handler callbacks.
 
   # Example
 
@@ -103,7 +112,7 @@ defmodule ThousandIsland.Handler do
 
     def handle_info({:send, msg}, {socket, state}) do
       ThousandIsland.Socket.send(socket, msg)
-      {:noreply, {socket, state}, socket.read_timeout}
+      {:noreply, {socket, state}}
     end
   end
   ```
@@ -289,12 +298,16 @@ defmodule ThousandIsland.Handler do
 
   @doc """
   This callback is called when a handler process has gone more than `timeout` ms without receiving
-  either remote data or a local message. The value used for `timeout` defaults to the
-  `read_timeout` value specified at server startup, and may be overridden on a one-shot or
-  persistent basis based on values returned from `c:handle_connection/2` or `c:handle_data/3`
-  calls. Note that it is NOT called on explicit `ThousandIsland.Socket.recv/3` calls as they have
-  their own timeout semantics. The underlying socket has NOT been closed by the time this callback
-  is called. The return value is ignored.
+  remote data from the client. The value used for `timeout` defaults to the `read_timeout` value
+  specified at server startup, and may be overridden on a one-shot or persistent basis based on
+  values returned from `c:handle_connection/2` or `c:handle_data/3` calls. Note that it is NOT
+  called on explicit `ThousandIsland.Socket.recv/3` calls as they have their own timeout
+  semantics. This callback is triggered only by absence of incoming client data; local messages
+  sent to the handler process do not reset the clock, and any GenServer-native timeouts will NOT
+  cause this callback to be called (if you wish to handle GenServer-native timeouts, you can do so
+  using the [upstream GenServer pattern](https://hexdocs.pm/elixir/GenServer.html#module-timeouts)
+  for this purpose). The underlying socket has NOT been closed by the time this callback is
+  called. The return value is ignored.
   """
   @callback handle_timeout(socket :: ThousandIsland.Socket.t(), state :: term()) :: term()
 
@@ -411,8 +424,8 @@ defmodule ThousandIsland.Handler do
         {:stop, reason, {socket, state}}
       end
 
-      def handle_info(:timeout, {%ThousandIsland.Socket{} = socket, state}) do
-        {:stop, {:shutdown, :timeout}, {socket, state}}
+      def handle_info(:read_timeout, {%ThousandIsland.Socket{} = socket, state}) do
+        {:stop, {:shutdown, :read_timeout}, {socket, state}}
       end
 
       @before_compile {ThousandIsland.Handler, :add_handle_info_fallback}
@@ -433,8 +446,8 @@ defmodule ThousandIsland.Handler do
         :ok
       end
 
-      # Called by GenServer if we hit our read_timeout. Socket is still open
-      def terminate({:shutdown, :timeout}, {%ThousandIsland.Socket{} = socket, state}) do
+      # Called when we hit our read_timeout. Socket is still open
+      def terminate({:shutdown, :read_timeout}, {%ThousandIsland.Socket{} = socket, state}) do
         _ = __MODULE__.handle_timeout(socket, state)
         ThousandIsland.Handler.do_socket_close(socket, :timeout)
       end
@@ -539,25 +552,53 @@ defmodule ThousandIsland.Handler do
     ThousandIsland.Telemetry.stop_span(socket.span, measurements, metadata)
   end
 
+  defp cancel_read_timer(%{read_timer: nil} = socket), do: socket
+
+  defp cancel_read_timer(%{read_timer: timer} = socket) do
+    _ = Process.cancel_timer(timer)
+
+    # Since we don't cancel timers until the final handle_continuation call in a callback, flush
+    # any :read_timeout message already delivered to the mailbox before we could cancel the timer
+    receive do
+      :read_timeout -> :ok
+    after
+      0 -> :ok
+    end
+
+    %{socket | read_timer: nil}
+  end
+
+  defp reset_read_timer(socket, :infinity), do: cancel_read_timer(socket)
+
+  defp reset_read_timer(socket, timeout) do
+    %{cancel_read_timer(socket) | read_timer: Process.send_after(self(), :read_timeout, timeout)}
+  end
+
   @doc false
   def handle_continuation(continuation, socket) do
+    socket = cancel_read_timer(socket)
+
     case continuation do
       {:continue, state} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        {:noreply, {socket, state}, socket.read_timeout}
+        socket = reset_read_timer(socket, socket.read_timeout)
+        {:noreply, {socket, state}}
 
       {:continue, state, {:continue, continue}} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
+        socket = reset_read_timer(socket, socket.read_timeout)
         {:noreply, {socket, state}, {:continue, continue}}
 
       {:continue, state, {:persistent, timeout}} ->
         socket = %{socket | read_timeout: timeout}
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        {:noreply, {socket, state}, timeout}
+        socket = reset_read_timer(socket, timeout)
+        {:noreply, {socket, state}}
 
       {:continue, state, timeout} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        {:noreply, {socket, state}, timeout}
+        socket = reset_read_timer(socket, timeout)
+        {:noreply, {socket, state}}
 
       {:switch_transport, {module, upgrade_opts}, state} ->
         handle_switch_continuation(socket, module, upgrade_opts, state, socket.read_timeout)
@@ -576,7 +617,7 @@ defmodule ThousandIsland.Handler do
         {:stop, {:shutdown, :local_closed}, {socket, state}}
 
       {:error, :timeout, state} ->
-        {:stop, {:shutdown, :timeout}, {socket, state}}
+        {:stop, {:shutdown, :read_timeout}, {socket, state}}
 
       {:error, reason, state} ->
         if socket.silent_terminate_on_error do
@@ -591,6 +632,7 @@ defmodule ThousandIsland.Handler do
     case ThousandIsland.Socket.upgrade(socket, module, upgrade_opts) do
       {:ok, socket} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
+        socket = reset_read_timer(socket, socket.read_timeout)
         {:noreply, {socket, state}, timeout_or_continue}
 
       {:error, reason} ->

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -5,13 +5,14 @@ defmodule ThousandIsland.Socket do
   """
 
   @enforce_keys [:socket, :transport_module, :read_timeout, :silent_terminate_on_error, :span]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:read_timer]
 
   @typedoc "A reference to a socket along with metadata describing how to use it"
   @type t :: %__MODULE__{
           socket: ThousandIsland.Transport.socket(),
           transport_module: module(),
           read_timeout: timeout(),
+          read_timer: reference() | nil,
           silent_terminate_on_error: boolean(),
           span: ThousandIsland.Telemetry.t()
         }

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -569,15 +569,30 @@ defmodule ThousandIsland.HandlerTest do
       require Logger
 
       @impl ThousandIsland.Handler
+      def handle_connection(_socket, state) do
+        # Flood ourselves with local messages to verify they don't reset the
+        # read timer (regression test for https://github.com/mtrudel/bandit/issues/577)
+        schedule_local_ping()
+        {:continue, state}
+      end
+
+      @impl ThousandIsland.Handler
       def handle_data("ping", _socket, state) do
         Logger.info("ping_received")
         {:continue, state}
+      end
+
+      def handle_info(:local_ping, {socket, state}) do
+        schedule_local_ping()
+        {:noreply, {socket, state}}
       end
 
       @impl ThousandIsland.Handler
       def handle_timeout(_socket, _state) do
         Logger.error("handle_timeout")
       end
+
+      defp schedule_local_ping, do: Process.send_after(self(), :local_ping, 10)
     end
 
     test "it should close the connection and call handle_timeout if the global read_timeout is reached waiting for client data" do
@@ -589,14 +604,33 @@ defmodule ThousandIsland.HandlerTest do
         capture_log(fn ->
           {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
           :gen_tcp.send(client, "ping")
-          assert :gen_tcp.recv(client, 0, read_timeout * 2) == {:error, :closed}
+          assert :gen_tcp.recv(client, 0, read_timeout * 5) == {:error, :closed}
           Process.sleep(100)
         end)
 
       # Ensure the initial message was received
       assert messages =~ "ping_received"
-      # Ensure that we saw the message displayed by the handle_timeout callback
+      # Ensure that we saw the message displayed by the handle_timeout callback,
+      # even though local handle_info messages kept arriving
       assert messages =~ "handle_timeout"
+    end
+
+    @tag capture_log: true
+    test "it should not close the connection if the client keeps sending within the read_timeout, even with local messages arriving" do
+      read_timeout = 100
+      {:ok, port} = start_handler(ReadTimeout, read_timeout: read_timeout)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # Send pings every 50ms (well within the 100ms timeout) for 300ms
+      for _ <- 1..6 do
+        :gen_tcp.send(client, "ping")
+        Process.sleep(50)
+      end
+
+      # Connection should still be open
+      assert :gen_tcp.recv(client, 0, 10) == {:error, :timeout}
+      :gen_tcp.close(client)
     end
 
     defmodule SyncReadTimeout do
@@ -609,11 +643,8 @@ defmodule ThousandIsland.HandlerTest do
         Logger.info("ping_received")
 
         case ThousandIsland.Socket.recv(socket, 0) do
-          {:error, reason} ->
-            {:error, reason, state}
-
-          {:ok, _binary} ->
-            {:continue, state}
+          {:error, reason} -> {:error, reason, state}
+          {:ok, _binary} -> {:continue, state}
         end
       end
 
@@ -688,6 +719,357 @@ defmodule ThousandIsland.HandlerTest do
 
       # Ensure that we saw the message displayed by the handle_continue callback
       assert messages =~ "handle_continue"
+    end
+
+    defmodule GenServerIdleTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_connection(_socket, state) do
+        # Send ourselves a message that returns a 1ms GenServer idle timeout.
+        # Prior to 1.5.0, the resulting :timeout message was indistinguishable
+        # from the read timer and would call handle_timeout/2, closing the
+        # connection. Under the new timer-based approach it ends up as a :timeout
+        # message in our inbox and is ignored here
+        send(self(), :trigger_genserver_timeout)
+        {:continue, state}
+      end
+
+      def handle_info(:trigger_genserver_timeout, {socket, state}) do
+        {:noreply, {socket, state}, 1}
+      end
+
+      def handle_info(:timeout, {socket, state}) do
+        {:noreply, {socket, state}}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout_fired")
+      end
+    end
+
+    test "it should NOT call handle_timeout when only a GenServer :timeout message fires (no client inactivity)" do
+      {:ok, port} = start_handler(GenServerIdleTimeout, read_timeout: 5_000)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          # Wait well past the 1ms GenServer idle timeout
+          Process.sleep(200)
+          # Connection should still be alive — the :timeout message was ignored
+          assert :gen_tcp.recv(client, 0, 50) == {:error, :timeout}
+          :gen_tcp.close(client)
+        end)
+
+      refute messages =~ "handle_timeout_fired"
+    end
+
+    defmodule SendDoesNotAffectTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_connection(_socket, state) do
+        Process.send_after(self(), :send_bytes, 1)
+        {:continue, state}
+      end
+
+      def handle_info(:send_bytes, {socket, state}) do
+        ThousandIsland.Socket.send(socket, "A")
+        Process.send_after(self(), :send_bytes, 1)
+        {:noreply, {socket, state}}
+      end
+    end
+
+    test "it should still timeout after read_timeout even though the server is sending bytes" do
+      {:ok, port} = start_handler(SendDoesNotAffectTimeout, read_timeout: 500)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # recv will see a bunch of separate reads, so reduce until we see a closed
+      assert Stream.unfold(client, fn client ->
+               case :gen_tcp.recv(client, 0, 1000) do
+                 {:ok, data} -> {data, client}
+                 {:error, :closed} -> nil
+               end
+             end)
+             |> Enum.flat_map(& &1)
+             |> Enum.join()
+             ~> string(min: 400, max: 600)
+
+      :gen_tcp.close(client)
+    end
+
+    defmodule LongHandlerCallbacksDoNotAffectTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data(_data, _socket, state) do
+        Process.sleep(200)
+        Process.send_after(self(), :send_bytes, 50)
+        {:continue, state}
+      end
+
+      def handle_info(:send_bytes, {socket, state}) do
+        ThousandIsland.Socket.send(socket, "A")
+        {:noreply, {socket, state}}
+      end
+    end
+
+    test "time spent within network-facing callbacks does not affect timeout" do
+      {:ok, port} = start_handler(LongHandlerCallbacksDoNotAffectTimeout, read_timeout: 100)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      :gen_tcp.send(client, "A")
+
+      # We expect the timeout (100ms) to be larger than the 50ms callback above
+      assert {:ok, ~c'A'} = :gen_tcp.recv(client, 0, 1000)
+
+      :gen_tcp.close(client)
+    end
+
+    defmodule LongGenServerCallbacksDoAffectTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_connection(_socket, state) do
+        send(self(), :sleep_then_send)
+        {:continue, state}
+      end
+
+      def handle_info(:sleep_then_send, {socket, state}) do
+        Process.sleep(75)
+
+        # This should occur after the timeout
+        Process.send_after(self(), :send_bytes, 50)
+        {:noreply, {socket, state}}
+      end
+
+      def handle_info(:send_bytes, {socket, state}) do
+        ThousandIsland.Socket.send(socket, "A")
+        {:noreply, {socket, state}}
+      end
+    end
+
+    test "time spent within GenServer native callbacks does affect timeout" do
+      {:ok, port} = start_handler(LongGenServerCallbacksDoAffectTimeout, read_timeout: 100)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # We expect the timeout (100ms) to be larger than the 150ms sleep above
+      assert {:error, :closed} = :gen_tcp.recv(client, 0, 1000)
+
+      :gen_tcp.close(client)
+    end
+
+    defmodule LongGenServerCallbacksHaveAContinuationEscapeHatch do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_connection(_socket, state) do
+        send(self(), :sleep_then_send)
+        {:continue, state}
+      end
+
+      def handle_info(:sleep_then_send, {socket, state}) do
+        Process.sleep(150)
+
+        Process.send_after(self(), :send_bytes, 50)
+        ThousandIsland.Handler.handle_continuation({:continue, state}, socket)
+      end
+
+      def handle_info(:send_bytes, {socket, state}) do
+        ThousandIsland.Socket.send(socket, "A")
+        {:noreply, {socket, state}}
+      end
+    end
+
+    test "GenServer native callbacks have an escape hatch to not affect timeout" do
+      {:ok, port} =
+        start_handler(LongGenServerCallbacksHaveAContinuationEscapeHatch, read_timeout: 100)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # We expect the handle_continuation to reset the timeout and for the send_bytes to fire
+      assert {:ok, ~c'A'} = :gen_tcp.recv(client, 0, 1000)
+      assert {:error, :closed} = :gen_tcp.recv(client, 0, 1000)
+
+      :gen_tcp.close(client)
+    end
+
+    defmodule EchoWithTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data(data, socket, state) do
+        ThousandIsland.Socket.send(socket, data)
+        {:continue, state}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout")
+      end
+    end
+
+    #
+    # Verify that the timer is properly reset each time client data arrives, so
+    # the timeout is always measured from the *last* client message, not the first.
+    #
+    test "timer resets from the last client message, not the first" do
+      read_timeout = 100
+      {:ok, port} = start_handler(EchoWithTimeout, read_timeout: read_timeout)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # Send several pings spread over 3x the timeout window — if the timer
+      # were not resetting, we'd be closed long before the last ping
+      for _ <- 1..4 do
+        :gen_tcp.send(client, "ping")
+        assert :gen_tcp.recv(client, 4) == {:ok, ~c"ping"}
+        Process.sleep(80)
+      end
+
+      # Now stop sending; the timeout should fire from the last ping
+      messages =
+        capture_log(fn ->
+          assert :gen_tcp.recv(client, 0, read_timeout * 3) == {:error, :closed}
+          Process.sleep(50)
+        end)
+
+      assert messages =~ "handle_timeout"
+    end
+
+    defmodule OneShotTimeoutWithLocalMessages do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data("start", _socket, state) do
+        # Return a tight 50ms one-shot timeout, then flood with local messages
+        schedule_local_message()
+        {:continue, state, 50}
+      end
+
+      def handle_data(_data, _socket, state) do
+        {:continue, state}
+      end
+
+      def handle_info(:local_message, {socket, state}) do
+        schedule_local_message()
+        {:noreply, {socket, state}}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout")
+      end
+
+      defp schedule_local_message do
+        Process.send_after(self(), :local_message, 10)
+      end
+    end
+
+    #
+    # Verify the {:continue, state, timeout} one-shot override is applied only
+    # to the next client-data window, and is not reset by local messages.
+    #
+    test "one-shot timeout fires based on client inactivity, not local messages" do
+      {:ok, port} = start_handler(OneShotTimeoutWithLocalMessages, read_timeout: 5_000)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          :gen_tcp.send(client, "start")
+          # Should close well within the global 5s timeout but ~50ms after "start"
+          assert :gen_tcp.recv(client, 0, 1_000) == {:error, :closed}
+          Process.sleep(50)
+        end)
+
+      assert messages =~ "handle_timeout"
+    end
+
+    defmodule PersistentTimeoutWithLocalMessages do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data("start", _socket, state) do
+        schedule_local_message()
+        {:continue, state, {:persistent, 80}}
+      end
+
+      def handle_data(_data, _socket, state) do
+        schedule_local_message()
+        {:continue, state}
+      end
+
+      def handle_info(:local_message, {socket, state}) do
+        schedule_local_message()
+        {:noreply, {socket, state}}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout")
+      end
+
+      defp schedule_local_message do
+        Process.send_after(self(), :local_message, 10)
+      end
+    end
+
+    #
+    # Verify {:persistent, timeout} continues to apply to subsequent rounds,
+    # still unaffected by local messages.
+    #
+    test "persistent timeout fires after client inactivity even across multiple data rounds" do
+      {:ok, port} = start_handler(PersistentTimeoutWithLocalMessages, read_timeout: 5_000)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          :gen_tcp.send(client, "start")
+          # Send a second message to confirm the persistent timeout carries over
+          Process.sleep(40)
+          :gen_tcp.send(client, "ping")
+          # Now go silent; should time out ~80ms after "ping" despite local messages
+          assert :gen_tcp.recv(client, 0, 1_000) == {:error, :closed}
+          Process.sleep(50)
+        end)
+
+      assert messages =~ "handle_timeout"
+    end
+
+    test "a GenServer :timeout message does not trigger handle_timeout" do
+      # Use a long read_timeout so it won't naturally expire during the test
+      {:ok, port} = start_handler(GenServerIdleTimeout, read_timeout: 5_000)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          # Wait well past the 1ms GenServer idle timeout
+          Process.sleep(200)
+          # Connection should still be alive — the :timeout message was ignored
+          assert :gen_tcp.recv(client, 0, 50) == {:error, :timeout}
+          :gen_tcp.close(client)
+        end)
+
+      refute messages =~ "handle_timeout_fired"
     end
 
     defmodule DoNothing do


### PR DESCRIPTION
Proposed solution to https://github.com/mtrudel/bandit/issues/577; uses an internal timer (tracked in `read_timer` within the socket struct) to separate out network timeouts from GenServer message timeouts. This has several benefits:

* Network timeouts are now tracked independently of any local mailbox messages which may be received. A busy local mailbox (and so anything happening locally on a schedule) does not reset the network timer; a 10 second read_timeout will ONLY measure 10 seconds of receive idleness.

* GenServer's native OTP semantics around timeouts can be used mostly as in any other GenServer. The only difference is that inbound async network traffic (ie: traffic that would result in a `handle_data` call) resets the GenServer timeout.