### PR TITLE
Back off on :emfile / :enfile in the accept loop instead of crashing the server

### DIFF
--- a/lib/thousand_island/acceptor.ex
+++ b/lib/thousand_island/acceptor.ex
@@ -3,6 +3,12 @@ defmodule ThousandIsland.Acceptor do
 
   use Task, restart: :transient
 
+  # How long to pause the accept loop when the system reports file descriptor
+  # exhaustion (:emfile / :enfile). We cannot accept while out of descriptors, so
+  # we back off briefly to let the situation resolve rather than spinning or
+  # crashing. This mirrors Ranch's behaviour (ranch_acceptor.erl).
+  @fd_exhaustion_wait 100
+
   @spec start_link(
           {server :: Supervisor.supervisor(), parent :: Supervisor.supervisor(), pos_integer(),
            ThousandIsland.ServerConfig.t()}
@@ -56,6 +62,24 @@ defmodule ThousandIsland.Acceptor do
 
       {:error, reason} when reason in [:econnaborted, :einval] ->
         ThousandIsland.Telemetry.span_event(span, reason)
+
+        accept(
+          listener_socket,
+          connection_sup_pid,
+          server_config,
+          handler_config,
+          span,
+          count + 1
+        )
+
+      {:error, reason} when reason in [:emfile, :enfile] ->
+        # File descriptors are exhausted, so nothing can be accepted right now.
+        # Back off briefly to let the situation resolve rather than crashing the
+        # acceptor (whose crash loop would escalate through the supervision
+        # tree, killing in-flight connections along the way). This mirrors
+        # Ranch's handling of the same condition
+        ThousandIsland.Telemetry.span_event(span, :emfile, %{error: reason})
+        Process.sleep(@fd_exhaustion_wait)
 
         accept(
           listener_socket,

--- a/lib/thousand_island/logger.ex
+++ b/lib/thousand_island/logger.ex
@@ -23,7 +23,8 @@ defmodule ThousandIsland.Logger do
   def attach_logger(:error) do
     events = [
       [:thousand_island, :acceptor, :spawn_error],
-      [:thousand_island, :acceptor, :econnaborted]
+      [:thousand_island, :acceptor, :econnaborted],
+      [:thousand_island, :acceptor, :emfile]
     ]
 
     :telemetry.attach_many("#{__MODULE__}.error", events, &__MODULE__.log_error/4, nil)

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -112,6 +112,23 @@ defmodule ThousandIsland.Telemetry do
 
       * `telemetry_span_context`: A unique identifier for this span
 
+  * `[:thousand_island, :acceptor, :emfile]`
+
+      Thousand Island was unable to accept a connection because the system is out of file
+      descriptors (`:emfile` or `:enfile`). The acceptor backs off briefly and keeps running
+      rather than crashing. Persistent occurrences indicate that the OS file descriptor limit
+      (`ulimit -n`) is too low, or that file descriptors are being leaked elsewhere in the node.
+
+      This event contains the following measurements:
+
+      * `monotonic_time`: The time of this event, in `:native` units
+      * `error`: The specific error returned by accept: `:emfile` if the per-process
+        descriptor limit was reached, or `:enfile` if the system-wide limit was reached
+
+      This event contains the following metadata:
+
+      * `telemetry_span_context`: A unique identifier for this span
+
   ## `[:thousand_island, :connection, *]`
 
   Represents Thousand Island handling a specific client request
@@ -306,6 +323,7 @@ defmodule ThousandIsland.Telemetry do
           :ready
           | :spawn_error
           | :econnaborted
+          | :emfile
           | :recv_error
           | :send_error
           | :sendfile_error

--- a/test/support/telemetry_helpers.ex
+++ b/test/support/telemetry_helpers.ex
@@ -8,6 +8,7 @@ defmodule TelemetryHelpers do
     [:thousand_island, :acceptor, :stop],
     [:thousand_island, :acceptor, :spawn_error],
     [:thousand_island, :acceptor, :econnaborted],
+    [:thousand_island, :acceptor, :emfile],
     [:thousand_island, :connection, :start],
     [:thousand_island, :connection, :stop],
     [:thousand_island, :connection, :ready],

--- a/test/thousand_island/acceptor_emfile_test.exs
+++ b/test/thousand_island/acceptor_emfile_test.exs
@@ -1,0 +1,152 @@
+defmodule ThousandIsland.AcceptorEmfileTest do
+  use ExUnit.Case, async: false
+
+  use Machete
+
+  # A transport that delegates to gen_tcp but lets the test inject a queue of
+  # accept/1 results via :persistent_term, so we can simulate the OS reporting
+  # file descriptor exhaustion. Once the queue is drained, real accepts resume.
+  defmodule FlakyTransport do
+    @behaviour ThousandIsland.Transport
+
+    def set_accept_results(key, results), do: :persistent_term.put({__MODULE__, key}, results)
+
+    @impl true
+    def listen(port, _opts),
+      do: :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true])
+
+    @impl true
+    def accept(listener_socket) do
+      key = :persistent_term.get({__MODULE__, :key})
+
+      case :persistent_term.get({__MODULE__, key}, []) do
+        [next | rest] ->
+          :persistent_term.put({__MODULE__, key}, rest)
+          # Inject a simulated error without consuming a real connection
+          {:error, next}
+
+        [] ->
+          :gen_tcp.accept(listener_socket)
+      end
+    end
+
+    @impl true
+    def handshake(socket), do: {:ok, socket}
+    @impl true
+    def upgrade(_socket, _opts), do: {:error, :unsupported_upgrade}
+    @impl true
+    def controlling_process(socket, pid), do: :gen_tcp.controlling_process(socket, pid)
+    @impl true
+    def recv(socket, length, timeout), do: :gen_tcp.recv(socket, length, timeout)
+    @impl true
+    def send(socket, data), do: :gen_tcp.send(socket, data)
+    @impl true
+    def sendfile(_s, _f, _o, _l), do: {:error, :not_supported}
+    @impl true
+    def getopts(socket, options), do: :inet.getopts(socket, options)
+    @impl true
+    def setopts(socket, options), do: :inet.setopts(socket, options)
+    @impl true
+    def shutdown(socket, way), do: :gen_tcp.shutdown(socket, way)
+    @impl true
+    def close(socket), do: :gen_tcp.close(socket)
+    @impl true
+    def sockname(socket), do: :inet.sockname(socket)
+    @impl true
+    def peername(socket), do: :inet.peername(socket)
+    @impl true
+    def peercert(_socket), do: {:error, :not_secure}
+    @impl true
+    def secure?, do: false
+    @impl true
+    def getstat(socket), do: :inet.getstat(socket)
+    @impl true
+    def negotiated_protocol(_socket), do: {:error, :protocol_not_negotiated}
+    @impl true
+    def connection_information(_socket), do: {:error, :not_secure}
+  end
+
+  defmodule Echo do
+    use ThousandIsland.Handler
+
+    @impl ThousandIsland.Handler
+    def handle_data(data, socket, state) do
+      ThousandIsland.Socket.send(socket, data)
+      {:continue, state}
+    end
+  end
+
+  defp acceptor_sup_pids(server_pid) do
+    server_pid
+    |> ThousandIsland.Server.acceptor_pool_supervisor_pid()
+    |> ThousandIsland.AcceptorPoolSupervisor.acceptor_supervisor_pids()
+  end
+
+  test "descriptor exhaustion does not take down the acceptor or its in-flight connections" do
+    key = make_ref()
+    :persistent_term.put({FlakyTransport, :key}, key)
+    FlakyTransport.set_accept_results(key, [])
+
+    {:ok, server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: Echo, transport_module: FlakyTransport, num_acceptors: 1}
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+    [acceptor_sup] = acceptor_sup_pids(server_pid)
+
+    # Open a connection while descriptors are still available
+    {:ok, existing} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    :ok = :gen_tcp.send(existing, "FIRST")
+    assert :gen_tcp.recv(existing, 0, 1000) == {:ok, "FIRST"}
+
+    # Now have accept report descriptor exhaustion five times in a row. Five
+    # failures is past the acceptor's restart budget (3 restarts in 5 seconds):
+    # if each error crashes the acceptor, the crash loop takes down the
+    # acceptor's supervisor, and with it every connection that acceptor is
+    # currently serving
+    FlakyTransport.set_accept_results(key, [:emfile, :enfile, :emfile, :enfile, :emfile])
+
+    # A new client unblocks the acceptor's pending accept; the acceptor then
+    # works through the injected errors (backing off briefly on each) before
+    # settling back into normal accepts
+    {:ok, fresh} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    Process.sleep(800)
+
+    # The in-flight connections survived the exhaustion window
+    :ok = :gen_tcp.send(existing, "STILL HERE")
+    assert :gen_tcp.recv(existing, 0, 1000) == {:ok, "STILL HERE"}
+    :ok = :gen_tcp.send(fresh, "HELLO")
+    assert :gen_tcp.recv(fresh, 0, 1000) == {:ok, "HELLO"}
+
+    # Nothing under the server was restarted, and new connections are accepted
+    # now that descriptors have freed up
+    assert acceptor_sup_pids(server_pid) == [acceptor_sup]
+    {:ok, late} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    :ok = :gen_tcp.send(late, "LATE")
+    assert :gen_tcp.recv(late, 0, 1000) == {:ok, "LATE"}
+
+    Enum.each([existing, fresh, late], &:gen_tcp.close/1)
+  end
+
+  test "an :emfile telemetry event is emitted on descriptor exhaustion" do
+    on_exit(TelemetryHelpers.attach_all_events(Echo))
+
+    key = make_ref()
+    :persistent_term.put({FlakyTransport, :key}, key)
+    FlakyTransport.set_accept_results(key, [:emfile])
+
+    {:ok, _server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: Echo, transport_module: FlakyTransport, num_acceptors: 1}
+      )
+
+    assert_receive {:telemetry, [:thousand_island, :acceptor, :emfile], measurements, metadata},
+                   1000
+
+    assert measurements ~> %{monotonic_time: integer(), error: :emfile}
+    assert metadata ~> %{handler: Echo, telemetry_span_context: reference()}
+  end
+end

--- a/test/thousand_island/acceptor_test.exs
+++ b/test/thousand_island/acceptor_test.exs
@@ -1,4 +1,4 @@
-defmodule ThousandIsland.AcceptorEmfileTest do
+defmodule ThousandIsland.AcceptorTest do
   use ExUnit.Case, async: false
 
   use Machete


### PR DESCRIPTION
Note: About ~40 lines of code & ~150 lines of test. Claude helped with tests.

## The problem

The accept loop in `ThousandIsland.Acceptor` treats any accept error it does not explicitly recognize as fatal:

```elixir
{:error, reason} ->
  ThousandIsland.Telemetry.stop_span(span, %{connections: count}, %{error: reason})
  raise "Unexpected error in accept: #{inspect(reason)}"
```

`:emfile` (the process hit its open file descriptor limit) and `:enfile` (the system wide file table is full) both land here. The acceptor task raises, its supervisor restarts it, `accept` immediately returns the same error, and the crash loop begins. Each supervision layer allows 3 restarts in 5 seconds, so the escalation path is short: 4 crashes kill an `AcceptorSupervisor`, 4 of those kill the `AcceptorPoolSupervisor`, and 4 of those kill the whole `ThousandIsland.Server`.

Two measured consequences on unmodified main (`cbc55d1`):

- Sustained exhaustion: with a transport whose `accept/1` persistently returns `{:error, :emfile}`, the entire server tree is dead about 10 ms after startup.
- A brief burst is bad too: because each `AcceptorSupervisor` is `rest_for_one` over the acceptor and its connection supervisor, a burst of just 4 errors on one acceptor kills that supervisor once, and every in-flight connection that acceptor was serving dies with it. Descriptor pressure on a busy node ends up dropping established connections that were doing nothing wrong.

The bitter part is that descriptor exhaustion is usually transient and self healing: some connections close, descriptors free up, and a server that simply waited would recover on its own. Instead the listener disappears at exactly the moment the node is busiest.

## Why it matters

Running out of file descriptors is one of the most common ways a busy BEAM node gets into trouble: a spike in concurrent connections, a low `ulimit -n`, or a descriptor leak elsewhere in the VM. The correct behavior for an acceptor under fd pressure is to throttle and stay alive, not to remove the listener. This exact crash has been reported in the wild against this library: issue #52 ("Unexpected error in accept: :emfile", March 2023) is this code path, and the acceptor's response to `:emfile` is unchanged since then.

## Prior art

Ranch, which Thousand Island is modeled on, handles this explicitly. From `ranch_acceptor.erl` (current master):

```erlang
%% Reduce the accept rate if we run out of FDs.
%% We can't accept anymore anyway, so we might as well wait
%% a little for the situation to resolve itself.
{error, Reason} when Reason =:= emfile; Reason =:= enfile ->
    ranch:log(warning,
        "Ranch acceptor reducing accept rate: out of file descriptors~n",
        [], Logger),
    receive after 100 -> ok end;
```

The Ranch guide documents this as a guarantee: "The accept rate of the listener will be automatically reduced, and a warning message will be logged."

The `accept(2)` man page defines the two errors as the per-process descriptor limit (`EMFILE`) and the system wide limit (`ENFILE`); neither says anything is wrong with the listener socket itself.

## Design

- On `:emfile` or `:enfile`, emit a telemetry event, sleep 100 ms (the same value Ranch uses, kept in a module attribute), and continue the accept loop. The sleep is deliberate backpressure: nothing useful can happen while descriptors are exhausted, and spinning would burn CPU and log volume.
- A telemetry event (`[:thousand_island, :acceptor, :emfile]`) is emitted rather than an inline log, matching the library's stated design of routing everything through telemetry. It is wired into `ThousandIsland.Logger` at the `:error` level, so operators who attach the logger get the same visibility Ranch gives them. The event carries the specific errno in its `error` measurement, since the remediation differs: `:emfile` points at `ulimit -n`, `:enfile` at the system wide table.
- Only `:emfile` and `:enfile` are handled here. The other transient accept errors named by `accept(2)` want a plain retry with no sleep, which is a separate concern proposed in a companion PR, so this change stays tightly scoped.
- The catch all `raise` stays in place for truly unexpected errors, so the library still fails loudly on conditions that really are unrecoverable.

## Regression tests

Two tests in `test/thousand_island/acceptor_emfile_test.exs`, driven by a test transport whose `accept/1` returns from an injected error queue and then falls through to real accepts.

The first opens an echo connection while descriptors are "available", then injects five consecutive `:emfile` / `:enfile` results. Five is chosen deliberately: it exceeds the 3-restarts-in-5-seconds budget, so on unmodified main the acceptor crash loop kills its supervisor and the established connection dies with it. With the fix, the test asserts the established connection keeps echoing through the exhaustion window, no supervisor restarts (same `AcceptorSupervisor` pid before and after), and a new connection is served once descriptors free up. The second test asserts the `:emfile` telemetry event fires with the errno in its `error` measurement.