### PR TITLE
Add a handshake_timeout server option (default 5000 ms)

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -141,6 +141,13 @@ defmodule ThousandIsland do
   above. Defaults to `5`
   * `read_timeout`: How long to wait for client data before closing the connection, in
   milliseconds. Defaults to 60_000
+  * `handshake_timeout`: How long to allow for a new connection to complete its transport
+  handshake (the TLS handshake, in the case of the SSL transport) before closing it, in
+  milliseconds. This bounds how long a client that connects but never (or too slowly) completes
+  the handshake can hold a handler process and a connection slot. Transports without a
+  handshake, such as `ThousandIsland.Transports.TCP`, ignore this value. May also be
+  `:infinity` to wait indefinitely, though this is not recommended for servers exposed to
+  untrusted clients. Defaults to 5_000
   * `shutdown_timeout`: How long to wait for existing client connections to complete before
   forcibly shutting those connections down at server shutdown time, in milliseconds. Defaults to
   15_000. May also be `:infinity` or `:brutal_kill` as described in the `Supervisor`
@@ -165,6 +172,7 @@ defmodule ThousandIsland do
           max_connections_retry_count: non_neg_integer(),
           max_connections_retry_wait: timeout(),
           read_timeout: timeout(),
+          handshake_timeout: timeout(),
           shutdown_timeout: timeout(),
           silent_terminate_on_error: boolean()
         ]

--- a/lib/thousand_island/handler_config.ex
+++ b/lib/thousand_island/handler_config.ex
@@ -5,13 +5,20 @@ defmodule ThousandIsland.HandlerConfig do
   This is used internally by `ThousandIsland.Handler`
   """
 
-  @enforce_keys [:handler_module, :transport_module, :read_timeout, :silent_terminate_on_error]
+  @enforce_keys [
+    :handler_module,
+    :transport_module,
+    :read_timeout,
+    :handshake_timeout,
+    :silent_terminate_on_error
+  ]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           handler_module: nil,
           transport_module: module(),
           read_timeout: timeout(),
+          handshake_timeout: timeout(),
           silent_terminate_on_error: boolean()
         }
 
@@ -25,6 +32,7 @@ defmodule ThousandIsland.HandlerConfig do
       handler_module: config.handler_module,
       transport_module: config.transport_module,
       read_timeout: config.read_timeout,
+      handshake_timeout: config.handshake_timeout,
       silent_terminate_on_error: config.silent_terminate_on_error
     }
   end

--- a/lib/thousand_island/server_config.ex
+++ b/lib/thousand_island/server_config.ex
@@ -20,6 +20,7 @@ defmodule ThousandIsland.ServerConfig do
           max_connections_retry_count: non_neg_integer(),
           max_connections_retry_wait: timeout(),
           read_timeout: timeout(),
+          handshake_timeout: timeout(),
           shutdown_timeout: timeout(),
           silent_terminate_on_error: boolean()
         }
@@ -37,6 +38,7 @@ defmodule ThousandIsland.ServerConfig do
             max_connections_retry_count: 5,
             max_connections_retry_wait: 1000,
             read_timeout: 60_000,
+            handshake_timeout: 5_000,
             shutdown_timeout: 15_000,
             silent_terminate_on_error: false
 

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -4,7 +4,14 @@ defmodule ThousandIsland.Socket do
   read, write, and otherwise manipulate a connection from a client.
   """
 
-  @enforce_keys [:socket, :transport_module, :read_timeout, :silent_terminate_on_error, :span]
+  @enforce_keys [
+    :socket,
+    :transport_module,
+    :read_timeout,
+    :handshake_timeout,
+    :silent_terminate_on_error,
+    :span
+  ]
   defstruct @enforce_keys ++ [:read_timer]
 
   @typedoc "A reference to a socket along with metadata describing how to use it"
@@ -12,6 +19,7 @@ defmodule ThousandIsland.Socket do
           socket: ThousandIsland.Transport.socket(),
           transport_module: module(),
           read_timeout: timeout(),
+          handshake_timeout: timeout(),
           read_timer: reference() | nil,
           silent_terminate_on_error: boolean(),
           span: ThousandIsland.Telemetry.t()
@@ -33,6 +41,7 @@ defmodule ThousandIsland.Socket do
       socket: raw_socket,
       transport_module: handler_config.transport_module,
       read_timeout: handler_config.read_timeout,
+      handshake_timeout: handler_config.handshake_timeout,
       silent_terminate_on_error: handler_config.silent_terminate_on_error,
       span: span
     }
@@ -46,7 +55,7 @@ defmodule ThousandIsland.Socket do
   """
   @spec handshake(t()) :: ThousandIsland.Transport.on_handshake()
   def handshake(%__MODULE__{} = socket) do
-    case socket.transport_module.handshake(socket.socket) do
+    case socket.transport_module.handshake(socket.socket, socket.handshake_timeout) do
       {:ok, inner_socket} ->
         {:ok, %{socket | socket: inner_socket}}
 

--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -119,8 +119,13 @@ defmodule ThousandIsland.Transport do
   Performs an initial handshake on a new client connection (such as that done
   when negotiating an SSL connection). Transports which do not have such a
   handshake can simply pass the socket through unchanged.
+
+  The handshake must complete within `timeout` milliseconds (or `:infinity`);
+  transports which perform a network handshake must abort and return an error if
+  the peer does not complete it in time, in order to bound the resources a slow
+  or stalled client can hold. Transports without a handshake can ignore `timeout`.
   """
-  @callback handshake(socket()) :: on_handshake()
+  @callback handshake(socket(), timeout()) :: on_handshake()
 
   @doc """
   Performs an upgrade of an existing client connection (for example upgrading

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -92,9 +92,10 @@ defmodule ThousandIsland.Transports.SSL do
   defdelegate accept(listener_socket), to: :ssl, as: :transport_accept
 
   @impl ThousandIsland.Transport
-  @spec handshake(socket()) :: ThousandIsland.Transport.on_handshake()
-  def handshake(socket) do
-    case :ssl.handshake(socket) do
+  @spec handshake(socket(), timeout()) :: ThousandIsland.Transport.on_handshake()
+  def handshake(socket, timeout) do
+    case :ssl.handshake(socket, timeout) do
+      {:ok, socket} -> {:ok, socket}
       {:ok, socket, _protocol_extensions} -> {:ok, socket}
       other -> other
     end

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -80,8 +80,8 @@ defmodule ThousandIsland.Transports.TCP do
   defdelegate accept(listener_socket), to: :gen_tcp
 
   @impl ThousandIsland.Transport
-  @spec handshake(socket()) :: ThousandIsland.Transport.on_handshake()
-  def handshake(socket), do: {:ok, socket}
+  @spec handshake(socket(), timeout()) :: ThousandIsland.Transport.on_handshake()
+  def handshake(socket, _timeout), do: {:ok, socket}
 
   @impl ThousandIsland.Transport
   @spec upgrade(socket(), options()) :: ThousandIsland.Transport.on_upgrade()

--- a/test/thousand_island/handshake_timeout_test.exs
+++ b/test/thousand_island/handshake_timeout_test.exs
@@ -1,0 +1,87 @@
+defmodule ThousandIsland.HandshakeTimeoutTest do
+  use ExUnit.Case, async: true
+
+  defmodule Echo do
+    use ThousandIsland.Handler
+
+    @impl ThousandIsland.Handler
+    def handle_data(data, socket, state) do
+      ThousandIsland.Socket.send(socket, data)
+      {:continue, state}
+    end
+  end
+
+  defp ssl_opts do
+    [
+      certfile: Path.join(__DIR__, "../support/cert.pem"),
+      keyfile: Path.join(__DIR__, "../support/key.pem")
+    ]
+  end
+
+  defp start_ssl(opts) do
+    args =
+      [
+        port: 0,
+        handler_module: Echo,
+        transport_module: ThousandIsland.Transports.SSL,
+        transport_options: ssl_opts()
+      ]
+      |> Keyword.merge(opts)
+
+    {:ok, server_pid} = start_supervised({ThousandIsland, args})
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+    {server_pid, port}
+  end
+
+  defp wait_until(fun, timeout) when timeout <= 0, do: fun.()
+
+  defp wait_until(fun, timeout) do
+    if fun.() do
+      true
+    else
+      Process.sleep(25)
+      wait_until(fun, timeout - 25)
+    end
+  end
+
+  test "a client that never completes the TLS handshake is dropped after handshake_timeout" do
+    {server_pid, port} = start_ssl(handshake_timeout: 200)
+
+    # Connect at the plain-TCP level and send nothing, stalling the TLS
+    # handshake indefinitely
+    {:ok, client} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+
+    # While the handshake is pending, the client occupies a connection process
+    assert wait_until(
+             fn -> match?({:ok, [_pid]}, ThousandIsland.connection_pids(server_pid)) end,
+             500
+           )
+
+    # Once handshake_timeout lapses the server must actively close the socket...
+    assert {:error, :closed} = :gen_tcp.recv(client, 0, 1000)
+
+    # ...and release the connection process (and with it the connection slot)
+    assert wait_until(fn -> ThousandIsland.connection_pids(server_pid) == {:ok, []} end, 500)
+  end
+
+  test "a well-behaved TLS client still completes the handshake and is served" do
+    {_server_pid, port} = start_ssl(handshake_timeout: 200)
+
+    {:ok, client} =
+      :ssl.connect(:localhost, port,
+        active: false,
+        verify: :verify_none,
+        cacertfile: Path.join(__DIR__, "../support/ca.pem")
+      )
+
+    :ok = :ssl.send(client, "HELLO")
+    assert :ssl.recv(client, 0, 1000) == {:ok, ~c"HELLO"}
+    :ssl.close(client)
+  end
+
+  test "handshake_timeout defaults to a finite value rather than :infinity" do
+    config = ThousandIsland.ServerConfig.new(handler_module: Echo)
+    assert is_integer(config.handshake_timeout)
+    assert config.handshake_timeout > 0
+  end
+end


### PR DESCRIPTION
Note: about ~50 lines of code and ~100 lines of test. Claude helped with the test and description below.

## The problem

When a connection is handed to its handler, the handler completes the transport handshake via `ThousandIsland.Socket.handshake/1`, which for the SSL transport calls `:ssl.handshake/1`. Per the OTP docs, `handshake/1` is equivalent to `handshake(HsSocket, infinity)`: there is no timeout. A client that opens a TCP connection to a TLS listener and then sends nothing, or dribbles the handshake out one byte at a time, keeps that handler process blocked in the handshake forever. The connection also counts against the acceptor's `num_connections` limit for its entire, unbounded lifetime.

Measured on unmodified main: a plain `:gen_tcp` client connects to a TLS listener configured with `read_timeout: 300` and sends nothing. The connection process is still there 1.7 seconds later (5.6 times the read timeout), and stays indefinitely. The read timeout cannot help, because it only governs data reads after the handshake completes; nothing bounds the handshake itself.

## Why it matters

This is a slowloris style denial of service exposure. An attacker, or just a fleet of broken clients behind a flaky network, can open connections to a TLS listener, never finish the handshakes, and pin handler processes and connection slots without ever presenting a valid ClientHello. Connections count from the moment the handler starts, so a modest number of stalled handshakes can fill an acceptor's capacity.

## Prior art

OTP's own `:ssl` documentation warns about precisely this, on the `Timeout` argument of `ssl:handshake`:

> Not setting the timeout makes the server more vulnerable to Denial of Service (DoS) attacks.

Ranch supplies a timeout by default: its `handshake_timeout` transport option is documented as "Maximum allowed time for the ranch:handshake/1,2 call to finish" and defaults to 5000 ms (`maps:get(handshake_timeout, TransOpts, 5000)` in `ranch_conns_sup.erl`). This PR gives Thousand Island the same protection with the same default.

## Design

A new top level `handshake_timeout` option (default `5_000`, `:infinity` allowed) threads through the same path the existing `read_timeout` already travels: `ServerConfig` to `HandlerConfig` to the `Socket` struct, and from there into the transport's handshake call. It is configurable per server exactly like every other timeout.

The visible consequence is that the `handshake` transport callback gains a timeout argument, going from `handshake(socket)` to `handshake(socket, timeout)`. This matches the shape of the other callbacks that take arguments (`recv/3`, `upgrade/2`) and matches Ranch, where the handshake takes a timeout. Both in-tree transports are updated; the TCP transport ignores the argument since it has no handshake. A custom transport would need to add the parameter (and can ignore it if it does no network handshake). There is precedent for growing this behaviour: `upgrade/2` was added as a new required callback in 1.3.0. If you would rather keep `handshake/1` and treat `handshake/2` as an optional callback for strict compatibility, that is a small variation and I am glad to adjust.

When the handshake times out, `:ssl.handshake/2` returns `{:error, :timeout}`, the handler stops with `{:shutdown, {:handshake, :timeout}}`, and the existing terminate path closes the socket and releases the slot. No new teardown machinery is needed.

This covers the accept time handshake, which is the primary exposure (any client that can reach a TLS listener). The `Socket.upgrade/3` path (STARTTLS style) has the same shape and could take the same treatment; it is left out to keep this PR focused and can be a small follow up.

## Regression tests

Three tests in `test/thousand_island/handshake_timeout_test.exs`:

- A plain TCP client connects to a TLS listener with `handshake_timeout: 200` and sends nothing. The test asserts the stall occupies a connection process, that the server actively closes the socket once the timeout lapses (the client's `recv` returns `{:error, :closed}` rather than hanging), and that the connection process and its slot are released.
- A well behaved TLS client still completes the handshake and is served under the same configuration.
- The default `handshake_timeout` is a finite integer, not `:infinity`.

## Verification

- All three tests fail on unmodified main and pass on the branch.
- Full suite on the branch: no new failures beyond the sandbox's usual reuseport and IPv6 environment set.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` are all clean on the branch.

## Performance and compatibility

No hot path impact: the handshake happens once per connection and already receives a timeout today (`:infinity`); this change passes a finite value instead. A normal handshake completes long before 5 seconds, so well behaved clients are unaffected. The one compatibility consideration is the `handshake/2` callback arity discussed above; both built in transports are updated here, and the optional callback variant is available if you prefer zero change for custom transports.

## Note

OTP flags this one itself and Ranch has shipped the 5000 ms default for years, so this fills in an expected default rather than inventing policy. Happy to add the matching `upgrade` path timeout as a follow up if you would like both.