### PR TITLE
Retry the transient network errors accept(2) documents instead of crashing the acceptor

### DIFF
--- a/lib/thousand_island/acceptor.ex
+++ b/lib/thousand_island/acceptor.ex
@@ -3,6 +3,27 @@ defmodule ThousandIsland.Acceptor do
 
   use Task, restart: :transient
 
+  # Transient errors which accept(2) documents as retryable: on Linux, accept()
+  # passes network errors already pending on the new socket back through the
+  # accept call itself, and instructs applications to "treat them like EAGAIN
+  # by retrying" (:etimedout is from the man page's adjacent list of errors
+  # that various kernels can also return). These are conditions of a single
+  # incoming connection, not of the listener, so we retry rather than crash
+  # the acceptor. :econnaborted and :einval are the same kind of condition,
+  # already handled in their own clause below with their own long-standing
+  # telemetry events
+  @transient_accept_errors [
+    :enetdown,
+    :enetunreach,
+    :ehostdown,
+    :ehostunreach,
+    :enonet,
+    :eproto,
+    :enoprotoopt,
+    :eopnotsupp,
+    :etimedout
+  ]
+
   @spec start_link(
           {server :: Supervisor.supervisor(), parent :: Supervisor.supervisor(), pos_integer(),
            ThousandIsland.ServerConfig.t()}
@@ -56,6 +77,22 @@ defmodule ThousandIsland.Acceptor do
 
       {:error, reason} when reason in [:econnaborted, :einval] ->
         ThousandIsland.Telemetry.span_event(span, reason)
+
+        accept(
+          listener_socket,
+          connection_sup_pid,
+          server_config,
+          handler_config,
+          span,
+          count + 1
+        )
+
+      {:error, reason} when reason in @transient_accept_errors ->
+        # A transient error on the incoming connection which accept(2) tells us
+        # to treat like EAGAIN. Emit an event for observability and keep
+        # accepting rather than crashing the acceptor (and, through restart
+        # escalation, the acceptor's supervisor and its live connections)
+        ThousandIsland.Telemetry.span_event(span, :accept_error, %{error: reason})
 
         accept(
           listener_socket,

--- a/lib/thousand_island/logger.ex
+++ b/lib/thousand_island/logger.ex
@@ -23,7 +23,8 @@ defmodule ThousandIsland.Logger do
   def attach_logger(:error) do
     events = [
       [:thousand_island, :acceptor, :spawn_error],
-      [:thousand_island, :acceptor, :econnaborted]
+      [:thousand_island, :acceptor, :econnaborted],
+      [:thousand_island, :acceptor, :accept_error]
     ]
 
     :telemetry.attach_many("#{__MODULE__}.error", events, &__MODULE__.log_error/4, nil)

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -112,6 +112,23 @@ defmodule ThousandIsland.Telemetry do
 
       * `telemetry_span_context`: A unique identifier for this span
 
+  * `[:thousand_island, :acceptor, :accept_error]`
+
+      Thousand Island encountered a transient network error while accepting a connection, of the
+      kind that `accept(2)` documents as retryable (an error already pending on the incoming
+      connection, such as `:ehostunreach` or `:enetdown`). These reflect a condition on one
+      incoming connection rather than a problem with the listener, so the acceptor retries and
+      keeps running rather than crashing.
+
+      This event contains the following measurements:
+
+      * `monotonic_time`: The time of this event, in `:native` units
+      * `error`: The transient error reason that was retried
+
+      This event contains the following metadata:
+
+      * `telemetry_span_context`: A unique identifier for this span
+
   ## `[:thousand_island, :connection, *]`
 
   Represents Thousand Island handling a specific client request
@@ -306,6 +323,7 @@ defmodule ThousandIsland.Telemetry do
           :ready
           | :spawn_error
           | :econnaborted
+          | :accept_error
           | :recv_error
           | :send_error
           | :sendfile_error

--- a/test/support/telemetry_helpers.ex
+++ b/test/support/telemetry_helpers.ex
@@ -8,6 +8,7 @@ defmodule TelemetryHelpers do
     [:thousand_island, :acceptor, :stop],
     [:thousand_island, :acceptor, :spawn_error],
     [:thousand_island, :acceptor, :econnaborted],
+    [:thousand_island, :acceptor, :accept_error],
     [:thousand_island, :connection, :start],
     [:thousand_island, :connection, :stop],
     [:thousand_island, :connection, :ready],

--- a/test/thousand_island/acceptor_test.exs
+++ b/test/thousand_island/acceptor_test.exs
@@ -1,4 +1,4 @@
-defmodule ThousandIsland.AcceptorTransientErrorTest do
+defmodule ThousandIsland.AcceptorTest do
   use ExUnit.Case, async: false
 
   use Machete

--- a/test/thousand_island/acceptor_transient_error_test.exs
+++ b/test/thousand_island/acceptor_transient_error_test.exs
@@ -1,0 +1,164 @@
+defmodule ThousandIsland.AcceptorTransientErrorTest do
+  use ExUnit.Case, async: false
+
+  use Machete
+
+  # A transport that injects a queue of accept/1 results (to simulate the OS
+  # returning transient network errors from accept), then falls through to real
+  # gen_tcp accepts.
+  defmodule FlakyTransport do
+    @behaviour ThousandIsland.Transport
+
+    def set_accept_results(key, results), do: :persistent_term.put({__MODULE__, key}, results)
+
+    @impl true
+    def listen(port, _opts),
+      do: :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true])
+
+    @impl true
+    def accept(listener_socket) do
+      key = :persistent_term.get({__MODULE__, :key})
+
+      case :persistent_term.get({__MODULE__, key}, []) do
+        [next | rest] ->
+          :persistent_term.put({__MODULE__, key}, rest)
+          {:error, next}
+
+        [] ->
+          :gen_tcp.accept(listener_socket)
+      end
+    end
+
+    @impl true
+    def handshake(socket), do: {:ok, socket}
+    @impl true
+    def upgrade(_socket, _opts), do: {:error, :unsupported_upgrade}
+    @impl true
+    def controlling_process(socket, pid), do: :gen_tcp.controlling_process(socket, pid)
+    @impl true
+    def recv(socket, length, timeout), do: :gen_tcp.recv(socket, length, timeout)
+    @impl true
+    def send(socket, data), do: :gen_tcp.send(socket, data)
+    @impl true
+    def sendfile(_s, _f, _o, _l), do: {:error, :not_supported}
+    @impl true
+    def getopts(socket, options), do: :inet.getopts(socket, options)
+    @impl true
+    def setopts(socket, options), do: :inet.setopts(socket, options)
+    @impl true
+    def shutdown(socket, way), do: :gen_tcp.shutdown(socket, way)
+    @impl true
+    def close(socket), do: :gen_tcp.close(socket)
+    @impl true
+    def sockname(socket), do: :inet.sockname(socket)
+    @impl true
+    def peername(socket), do: :inet.peername(socket)
+    @impl true
+    def peercert(_socket), do: {:error, :not_secure}
+    @impl true
+    def secure?, do: false
+    @impl true
+    def getstat(socket), do: :inet.getstat(socket)
+    @impl true
+    def negotiated_protocol(_socket), do: {:error, :protocol_not_negotiated}
+    @impl true
+    def connection_information(_socket), do: {:error, :not_secure}
+  end
+
+  defmodule Echo do
+    use ThousandIsland.Handler
+
+    @impl ThousandIsland.Handler
+    def handle_data(data, socket, state) do
+      ThousandIsland.Socket.send(socket, data)
+      {:continue, state}
+    end
+  end
+
+  defp acceptor_sup_pids(server_pid) do
+    server_pid
+    |> ThousandIsland.Server.acceptor_pool_supervisor_pid()
+    |> ThousandIsland.AcceptorPoolSupervisor.acceptor_supervisor_pids()
+  end
+
+  # The accept(2) retry list, plus :etimedout (same man page, "various kernels"
+  # note) and :einval (retried by Thousand Island since 1.3.12)
+  @transient [
+    :enetdown,
+    :enetunreach,
+    :ehostdown,
+    :ehostunreach,
+    :enonet,
+    :eproto,
+    :enoprotoopt,
+    :eopnotsupp,
+    :etimedout,
+    :einval
+  ]
+
+  test "transient accept(2) network errors are retried rather than crashing the acceptor" do
+    key = make_ref()
+    :persistent_term.put({FlakyTransport, :key}, key)
+    FlakyTransport.set_accept_results(key, [])
+
+    {:ok, server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: Echo, transport_module: FlakyTransport, num_acceptors: 1}
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+    [acceptor_sup] = acceptor_sup_pids(server_pid)
+
+    # Open a connection before any trouble starts
+    {:ok, existing} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    :ok = :gen_tcp.send(existing, "FIRST")
+    assert :gen_tcp.recv(existing, 0, 1000) == {:ok, "FIRST"}
+
+    # Now have accept return every transient error in the set, back to back.
+    # Ten in a row is far past the acceptor's restart budget (3 restarts in 5
+    # seconds): if these crash the acceptor, its supervisor comes down too,
+    # taking the acceptor's in-flight connections with it
+    FlakyTransport.set_accept_results(key, @transient)
+
+    # A new client unblocks the pending accept; the acceptor then works
+    # through the injected errors
+    {:ok, fresh} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    Process.sleep(300)
+
+    # The in-flight connections survived the errors
+    :ok = :gen_tcp.send(existing, "STILL HERE")
+    assert :gen_tcp.recv(existing, 0, 1000) == {:ok, "STILL HERE"}
+    :ok = :gen_tcp.send(fresh, "HELLO")
+    assert :gen_tcp.recv(fresh, 0, 1000) == {:ok, "HELLO"}
+
+    # Nothing under the server was restarted, and new connections still flow
+    assert acceptor_sup_pids(server_pid) == [acceptor_sup]
+    {:ok, late} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    :ok = :gen_tcp.send(late, "LATE")
+    assert :gen_tcp.recv(late, 0, 1000) == {:ok, "LATE"}
+
+    Enum.each([existing, fresh, late], &:gen_tcp.close/1)
+  end
+
+  test "a transient accept error emits an :accept_error telemetry event carrying the reason" do
+    on_exit(TelemetryHelpers.attach_all_events(Echo))
+
+    key = make_ref()
+    :persistent_term.put({FlakyTransport, :key}, key)
+    FlakyTransport.set_accept_results(key, [:ehostunreach])
+
+    {:ok, _server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: Echo, transport_module: FlakyTransport, num_acceptors: 1}
+      )
+
+    assert_receive {:telemetry, [:thousand_island, :acceptor, :accept_error], measurements,
+                    metadata},
+                   1000
+
+    assert measurements ~> %{monotonic_time: integer(), error: :ehostunreach}
+    assert metadata ~> %{handler: Echo, telemetry_span_context: reference()}
+  end
+end


### PR DESCRIPTION
Note: about ~60 lines of code and ~150 lines of test. Claude helped with the description and tests.

## The problem

The accept loop retries only `:econnaborted` and `:einval`, and treats every other accept error as fatal:

```elixir
{:error, reason} when reason in [:econnaborted, :einval] ->
  ThousandIsland.Telemetry.span_event(span, reason)
  accept(...)

{:error, :closed} ->
  ThousandIsland.Telemetry.stop_span(span, %{connections: count})

{:error, reason} ->
  ThousandIsland.Telemetry.stop_span(span, %{connections: count}, %{error: reason})
  raise "Unexpected error in accept: #{inspect(reason)}"
```

On Linux, `accept` can return a network error that was already pending on the incoming connection: `:enetdown`, `:enetunreach`, `:ehostdown`, `:ehostunreach`, `:enonet`, `:eproto`, `:enoprotoopt`, `:eopnotsupp`, and on some kernels `:etimedout`. Every one of these hits the catch all `raise`. A transient condition on a single inbound connection crashes the acceptor, and a short burst of them escalates: 4 crashes within 5 seconds kill the `AcceptorSupervisor` (dropping that acceptor's in-flight connections, since the connection supervisor lives under it), and sustained bursts walk up the tree toward the whole server, exactly as with descriptor exhaustion.

## Why it matters

These errors are not exotic. They are what the kernel hands back when a connection arrives carrying a pending ICMP error, when a route flaps, or when a probe touches the port in a way the OS surfaces oddly. The existing `:einval` handling was added in 1.3.12 (#162) for exactly this class of thing: HAProxy TCP health checks on FreeBSD, via Bandit issue 460. Today every other error in the set crashes the acceptor instead of being shrugged off.

## Prior art

The Linux `accept(2)` man page is explicit in its error handling note: "Linux accept() (and accept4()) passes already-pending network errors on the new socket as an error code from accept()", and applications should "treat them like EAGAIN by retrying"; for TCP/IP it names "ENETDOWN, EPROTO, ENOPROTOOPT, EHOSTDOWN, ENONET, EHOSTUNREACH, EOPNOTSUPP, and ENETUNREACH". That list is the basis for this change. `:etimedout` is included from the man page's adjacent note that "Various Linux kernels can return other errors such as ENOSR, ESOCKTNOSUPPORT, EPROTONOSUPPORT, ETIMEDOUT"; of those four, only `ETIMEDOUT` is a plausible transient condition of one incoming TCP connection, so the other three deliberately stay on the fail-loud path.

Ranch goes further and retries every accept error that is not `emfile`, `enfile`, or `closed` (a bare `{error, _} -> ok` clause in `ranch_acceptor.erl`). This PR takes the more conservative path of enumerating the documented set, which keeps Thousand Island's fail-loud behavior for anything genuinely unexpected, such as a corrupt listener socket.

## Design

- The transient set is a module attribute, so the list sits in one place and is easy to review against the man page.
- The existing `:econnaborted` / `:einval` clause is untouched, and both keep emitting their existing events. Nothing about current behavior changes; this PR only widens what is survivable.
- The new errnos emit a single `[:thousand_island, :acceptor, :accept_error]` event carrying the specific error in its `error` measurement, following the pattern of `recv_error` and friends. One event to attach to, with the errno available for anyone who wants to discriminate. It is documented and wired into `ThousandIsland.Logger` at the `:error` level.
- The retry has no sleep, unlike the descriptor exhaustion backoff proposed in a companion PR. There is nothing to wait out here; the next accept may well succeed immediately.
- The catch all `raise` stays for anything not in the set.

## Regression tests

Two tests in `test/thousand_island/acceptor_transient_error_test.exs`, using an error-injecting transport. The first opens an echo connection, then injects all ten errnos (the nine new ones plus `:einval`, which also regression-covers the existing path) back to back. Ten consecutive crashes would blow the acceptor's restart budget several times over, so on unmodified main the established connection is killed by the supervisor collapse and the test fails deterministically. With the fix, the established connection keeps echoing through the error burst, the `AcceptorSupervisor` pid is unchanged, and new connections are served afterward. The second test asserts the `:accept_error` event fires carrying the specific errno (`:ehostunreach`) in its measurements.

## Verification

- Both tests fail on unmodified main across seeds and pass on the branch.
- Full suite on the branch: no new failures beyond the sandbox's usual reuseport and IPv6 environment set.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` are all clean on the branch.

## Performance and compatibility

No hot path impact: the new clause runs only when `accept` returns one of the listed errors. Fully backward compatible: the existing `:econnaborted` and `:einval` events are untouched, and the only addition to the public surface is the new documented `:accept_error` event.

