### PR TITLE
Survive handler start failure: close the socket and keep accepting

### DIFF
--- a/lib/thousand_island/acceptor.ex
+++ b/lib/thousand_island/acceptor.ex
@@ -54,6 +54,23 @@ defmodule ThousandIsland.Acceptor do
           count + 1
         )
 
+      {:error, {:spawn_error, reason}} ->
+        # The socket was accepted fine but a handler process could not be
+        # started for it (the socket has already been closed by
+        # ThousandIsland.Connection). This is a failure of one connection, so
+        # emit a spawn error and keep accepting rather than crashing the
+        # acceptor
+        ThousandIsland.Telemetry.span_event(span, :spawn_error, %{error: reason})
+
+        accept(
+          listener_socket,
+          connection_sup_pid,
+          server_config,
+          handler_config,
+          span,
+          count + 1
+        )
+
       {:error, reason} when reason in [:econnaborted, :einval] ->
         ThousandIsland.Telemetry.span_event(span, reason)
 

--- a/lib/thousand_island/connection.ex
+++ b/lib/thousand_island/connection.ex
@@ -8,10 +8,8 @@ defmodule ThousandIsland.Connection do
           ThousandIsland.HandlerConfig.t(),
           ThousandIsland.Telemetry.t()
         ) ::
-          :ignore
-          | :ok
-          | {:ok, pid, info :: term}
-          | {:error, :too_many_connections | {:already_started, pid} | term}
+          :ok
+          | {:error, :too_many_connections | {:spawn_error, term}}
   def start(
         sup_pid,
         raw_socket,
@@ -95,8 +93,20 @@ defmodule ThousandIsland.Connection do
         handler_config.transport_module.close(raw_socket)
         {:error, :too_many_connections}
 
+      {:error, reason} ->
+        # The handler process could not be started, for example because its
+        # init returned `{:stop, reason}`. We still own the raw socket at this
+        # point, so close it (rather than leaving it open until this acceptor
+        # exits), and report a spawn error so the acceptor can carry on rather
+        # than crashing on an otherwise-successful accept
+        _ = handler_config.transport_module.close(raw_socket)
+        {:error, {:spawn_error, reason}}
+
       other ->
-        other
+        # `:ignore`, or a nonstandard return from the handler's start_link.
+        # Handled exactly as above
+        _ = handler_config.transport_module.close(raw_socket)
+        {:error, {:spawn_error, other}}
     end
   end
 end

--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -86,12 +86,15 @@ defmodule ThousandIsland.Telemetry do
   * `[:thousand_island, :acceptor, :spawn_error]`
 
       Thousand Island was unable to spawn a process to handle a connection. This occurs when too
-      many connections are in progress; you may want to look at increasing the `num_connections`
-      configuration parameter
+      many connections are in progress (in which case you may want to look at increasing the
+      `num_connections` configuration parameter), or when the configured handler failed to start
+      (for example if its `init/1` returned `{:stop, reason}` or `:ignore`)
 
       This event contains the following measurements:
 
       * `monotonic_time`: The time of this event, in `:native` units
+      * `error`: Present when a handler process failed to start; the reason the start failed.
+        Not present when the connection limit was reached
 
       This event contains the following metadata:
 

--- a/test/thousand_island/acceptor_test.exs
+++ b/test/thousand_island/acceptor_test.exs
@@ -1,4 +1,4 @@
-defmodule ThousandIsland.SpawnFailureTest do
+defmodule ThousandIsland.AcceptorTest do
   use ExUnit.Case, async: false
 
   use Machete

--- a/test/thousand_island/spawn_failure_test.exs
+++ b/test/thousand_island/spawn_failure_test.exs
@@ -1,0 +1,84 @@
+defmodule ThousandIsland.SpawnFailureTest do
+  use ExUnit.Case, async: false
+
+  use Machete
+
+  # A handler_module (with a real child_spec via `use GenServer`) whose init
+  # fails, modelling a handler that cannot start (a failed resource acquisition
+  # or registry registration at connection setup time, say). The failure mode
+  # is selected via handler_options.
+  defmodule FailInitHandler do
+    use GenServer, restart: :temporary
+
+    def start_link({handler_options, genserver_options}),
+      do: GenServer.start_link(__MODULE__, handler_options, genserver_options)
+
+    @impl true
+    def init(:stop), do: {:stop, :intentional_init_failure}
+    def init(:ignore), do: :ignore
+  end
+
+  defp acceptor_pids(server_pid) do
+    server_pid
+    |> ThousandIsland.Server.acceptor_pool_supervisor_pid()
+    |> ThousandIsland.AcceptorPoolSupervisor.acceptor_supervisor_pids()
+    |> Enum.flat_map(fn sup ->
+      for {:acceptor, pid, _, _} <- Supervisor.which_children(sup), is_pid(pid), do: pid
+    end)
+  end
+
+  for mode <- [:stop, :ignore] do
+    test "a handler whose init returns #{inspect(mode)} does not crash the acceptor, and the socket is closed" do
+      {:ok, server_pid} =
+        start_supervised(
+          {ThousandIsland,
+           port: 0,
+           handler_module: FailInitHandler,
+           handler_options: unquote(mode),
+           num_acceptors: 1}
+        )
+
+      {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+      acceptors_before = acceptor_pids(server_pid)
+
+      # Six connections in a row; each accept succeeds but no handler can be
+      # started. Six is past the acceptor's restart budget (3 restarts in 5
+      # seconds), so if each failure crashed the acceptor this would take down
+      # its supervisor as well
+      for _ <- 1..6 do
+        {:ok, client} = :gen_tcp.connect(:localhost, port, [:binary, active: false], 1000)
+
+        # The server must actively close the accepted socket rather than leave
+        # it dangling
+        assert {:error, :closed} = :gen_tcp.recv(client, 0, 1000)
+        :gen_tcp.close(client)
+      end
+
+      # The very same acceptor process is still in place: it never crashed,
+      # let alone escalated into its supervision tree
+      assert acceptor_pids(server_pid) == acceptors_before
+      assert Process.alive?(server_pid)
+      assert {:ok, []} = ThousandIsland.connection_pids(server_pid)
+    end
+  end
+
+  test "a spawn failure emits a spawn_error telemetry event carrying the reason" do
+    on_exit(TelemetryHelpers.attach_all_events(FailInitHandler))
+
+    {:ok, server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: FailInitHandler, handler_options: :stop, num_acceptors: 1}
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+    {:ok, _client} = :gen_tcp.connect(:localhost, port, [:binary, active: false], 1000)
+
+    assert_receive {:telemetry, [:thousand_island, :acceptor, :spawn_error], measurements,
+                    metadata},
+                   1000
+
+    assert measurements ~> %{monotonic_time: integer(), error: :intentional_init_failure}
+    assert metadata ~> %{handler: FailInitHandler, telemetry_span_context: reference()}
+  end
+end


### PR DESCRIPTION
Note: about ~50 lines of code and ~100 lines of test. Claude helped with the description below and test cases.

## The problem

After a successful `accept`, the acceptor calls `ThousandIsland.Connection.start/5`, which asks the connection `DynamicSupervisor` to start the handler process. If that start fails for any reason other than `:max_children`, `Connection.start` falls through its final clause:

```elixir
other ->
  other
```

and returns the raw value to the acceptor. For `{:error, reason}` (a handler whose `init/1` returned `{:stop, reason}`, say) the acceptor's catch all raises "Unexpected error in accept: ...". For `:ignore` (a handler whose `init/1` opted out) nothing in the `with` else block matches at all, and the acceptor dies with a `WithClauseError` instead. Either way the acceptor crashes on a per connection condition, and repeated occurrences escalate through the supervision tree exactly as described in the descriptor exhaustion PR: 4 crashes in 5 seconds kill the `AcceptorSupervisor` and its live connections.

There is also a socket ownership loose end on this path: the accepted socket is never explicitly closed. Today that is masked, because the socket dies with the crashing acceptor process. But it means the crash is load bearing for cleanup, and any fix that keeps the acceptor alive must add the close, which this PR does.

Verified on unmodified main: with a handler whose `init/1` returns `{:stop, reason}`, a single connection crashes the acceptor, and six connections in a row replace the acceptor pid and kill its supervisor.

## Why it matters

A handler can fail to start for ordinary reasons: it registers itself in a `Registry` during `init` and hits a conflict, it acquires a limited resource that is momentarily exhausted, or it returns `{:stop, reason}` or `:ignore` under some condition. None of these should take down the acceptor that accepted the connection, and none of them should leave the client hanging. The failure is per connection and should be handled per connection.

## Prior art

This is Ranch parity. When a connection process fails to start, Ranch logs the error, closes the socket, and keeps going. From `ranch_conns_sup.erl`:

```erlang
Ret ->
    To ! self(),
    ranch:log(error,
        "Ranch listener ~p connection process start failure; "
        "~p:start_link/3 returned: ~0p~n",
        [Ref, Protocol, Ret], Logger),
    Transport:close(Socket),
```

The supervisor and acceptor stay up. A handler that cannot start is a connection level problem, not an acceptor level fault.

## Design

Two small, matched changes:

- `ThousandIsland.Connection.start/5` now handles the non-`:max_children` failure returns explicitly: it closes the raw socket (which it still owns at that point) and returns a structured `{:error, {:spawn_error, reason}}`. `{:error, reason}` from the supervisor unwraps to the inner reason; `:ignore` or any nonstandard `start_link` return is passed through as is. The spec is tightened to the two outcomes that can actually occur, `:ok` or an error tuple.
- `ThousandIsland.Acceptor` gains a clause matching `{:error, {:spawn_error, reason}}` which emits the existing `:spawn_error` telemetry event and continues the accept loop.

Reusing the existing `:spawn_error` event is deliberate: from an operator's point of view, "could not start a handler for this connection" is the same category whether the cause is the connection limit or a failed handler start, and consumers already handle the event. To keep the two cases distinguishable, the handler start failure now carries the failure reason in the event's `error` measurement (the connection limit case is unchanged and carries none), and the event documentation says so.

Closing the socket in `Connection.start` rather than in the acceptor keeps ownership logic in one place: it is where the socket is handed off on success, so it is also the right place to clean up on failure. This matches the `:max_children` branch a few lines up, which already closes there.

## Regression tests

Three tests in `test/thousand_island/spawn_failure_test.exs`, driven by a handler whose `init/1` fails in a mode chosen via `handler_options` (`{:stop, reason}` or `:ignore`):

- For each failure mode: six connections in a row (past the acceptor's restart budget, were it crashing) against a single acceptor. Asserts every client socket is actively closed (`recv` returns `{:error, :closed}` rather than hanging), and that the very same acceptor pid is still in place afterward, so the acceptor never crashed at all, let alone escalated. On unmodified main these fail deterministically.
- A spawn failure emits the `:spawn_error` event with the init failure reason in its `error` measurement.

## Verification

- All three tests fail on unmodified main across seeds and pass on the branch.
- Full suite on the branch: no new failures beyond the sandbox's usual reuseport and IPv6 environment set.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` are all clean on the branch.

## Performance and compatibility

No hot path impact: the new logic runs only when a handler fails to start. The `Connection.start` spec is narrowed to match what the function actually returns; the module is `@moduledoc false`, so there is no public API change. The `:spawn_error` event gains an optional documented measurement; its existing shape for the connection limit case is unchanged.

## Note

The explicit close also means a client whose connection was accepted but could not be handled sees a prompt close instead of a dead air socket. As with the companion acceptor PRs, this can be reviewed alone or folded into a combined "harden the acceptor" change.