### PR TITLE
add status/1 and info/1 runtime introspection

### DIFF
--- a/lib/thousand_island.ex
+++ b/lib/thousand_island.ex
@@ -272,6 +272,85 @@ defmodule ThousandIsland do
     end)
   end
 
+  @typedoc "The status of a server's listener"
+  @type status :: :running | :suspended
+
+  @doc """
+  Returns the current status of the given server: `:running` if it is accepting new connections,
+  or `:suspended` if the acceptance of new connections has been suspended via `suspend/1`.
+  Existing connections are not reflected in (and are unaffected by) this value; a `:suspended`
+  server may well still be serving many previously accepted connections
+  """
+  @spec status(Supervisor.supervisor()) :: status()
+  def status(supervisor) do
+    case ThousandIsland.Server.listener_pid(supervisor) do
+      nil -> :suspended
+      _pid -> :running
+    end
+  end
+
+  @doc """
+  Returns a map of information about the given server, suitable for observability and debugging
+  purposes such as health checks, remote consoles and dashboards:
+
+  * `status`: `:running` or `:suspended`, as per `status/1`
+  * `local_info`: the address and port that the server is listening on, as per
+    `listener_info/1`, or `nil` if the server is suspended
+  * `active_connections`: the number of connection handler processes currently alive across the
+    entire server. As with `connection_pids/1`, this is inherently a leaky notion in the face of
+    concurrency; connections may come and go while this function runs
+
+  Note that this function walks the server's supervision tree on every call, and so is intended
+  to be called at human timescales; it is not optimized for use in hot loops. One especially
+  useful application is graceful draining at deploy time, without having to stop the server:
+
+  ```elixir
+  :ok = ThousandIsland.suspend(server_pid)
+
+  # Poll (at whatever interval and deadline suits) until existing connections finish up
+  {:ok, %{active_connections: 0}} = ThousandIsland.info(server_pid)
+  ```
+  """
+  @spec info(Supervisor.supervisor()) ::
+          {:ok,
+           %{
+             status: status(),
+             local_info: ThousandIsland.Transport.socket_info() | nil,
+             active_connections: non_neg_integer()
+           }}
+          | :error
+  def info(supervisor) do
+    case ThousandIsland.Server.acceptor_pool_supervisor_pid(supervisor) do
+      nil ->
+        :error
+
+      acceptor_pool_pid ->
+        local_info =
+          case listener_info(supervisor) do
+            {:ok, local_info} -> local_info
+            :error -> nil
+          end
+
+        {:ok,
+         %{
+           status: status(supervisor),
+           local_info: local_info,
+           active_connections: count_connections(acceptor_pool_pid)
+         }}
+    end
+  end
+
+  defp count_connections(acceptor_pool_pid) do
+    acceptor_pool_pid
+    |> ThousandIsland.AcceptorPoolSupervisor.acceptor_supervisor_pids()
+    |> Enum.reduce(0, fn acceptor_sup_pid, acc ->
+      case ThousandIsland.AcceptorSupervisor.connection_sup_pid(acceptor_sup_pid) do
+        nil -> acc
+        connection_sup_pid -> acc + DynamicSupervisor.count_children(connection_sup_pid).active
+      end
+    end)
+  end
+
   @doc """
   Synchronously stops the given server, waiting up to the given number of milliseconds
   for existing connections to finish up. Immediately upon calling this function,

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -388,6 +388,51 @@ defmodule ThousandIsland.ServerTest do
     end
   end
 
+  describe "status / info" do
+    test "should report status across the suspend / resume lifecycle" do
+      {:ok, server_pid, port} = start_handler(LongEcho)
+      assert ThousandIsland.status(server_pid) == :running
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # Make sure the socket has transitioned ownership to the connection process
+      Process.sleep(100)
+
+      :ok = ThousandIsland.suspend(server_pid)
+      assert ThousandIsland.status(server_pid) == :suspended
+
+      # Suspending does not affect existing connections, and info reflects both facts
+      assert {:ok, %{status: :suspended, local_info: nil, active_connections: 1}} =
+               ThousandIsland.info(server_pid)
+
+      :ok = ThousandIsland.resume(server_pid)
+      assert ThousandIsland.status(server_pid) == :running
+
+      :gen_tcp.close(client)
+    end
+
+    test "should report local info and track active connection counts" do
+      {:ok, server_pid, port} = start_handler(LongEcho)
+
+      assert {:ok, %{status: :running, local_info: {_ip, ^port}, active_connections: 0}} =
+               ThousandIsland.info(server_pid)
+
+      {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+      {:ok, other_client} = :gen_tcp.connect(:localhost, port, active: false)
+
+      # Make sure the sockets have transitioned ownership to the connection processes
+      Process.sleep(100)
+
+      assert {:ok, %{active_connections: 2}} = ThousandIsland.info(server_pid)
+
+      :gen_tcp.close(client)
+      :gen_tcp.close(other_client)
+      Process.sleep(100)
+
+      assert {:ok, %{active_connections: 0}} = ThousandIsland.info(server_pid)
+    end
+  end
+
   describe "configuration" do
     test "tcp should allow default options to be overridden" do
       {:ok, _, port} = start_handler(ReadOpt, transport_options: [send_timeout: 1230])


### PR DESCRIPTION
Note: ~80 lines of code / 50 lines of test. Claude helped with desc and tests and coding.

## What this adds

Two additive functions on the `ThousandIsland` module:

* `status/1` returns `:running` or `:suspended` for a server, completing the lifecycle API that `suspend/1` and `resume/1` started (today you can change the state but not ask what it is).
* `info/1` returns `{:ok, %{status: status, local_info: {ip, port} | nil, active_connections: n}}`, a one-call observability snapshot of a running server.

## Why it matters

Thousand Island exposes `listener_info/1` and `connection_pids/1` and nothing else about a running server. Ranch has answered "what state is this listener in, and how many connections is it carrying" since 1.3 through `ranch:get_status/1`, `ranch:info/1`, and `ranch:procs/2`, and its documentation builds its graceful-drain recipe on exactly those calls. Operators of Bandit and Thousand Island deployments keep bumping into this gap in Kubernetes-shaped ways: liveness and readiness probes (bandit#310), rebalancing connections at scale-up (bandit#572), and "how loaded is this node" dashboards all want a cheap answer to the connection-count question, and today the only options are counting `connection_pids/1` (allocates a list of every pid just to take its length) or reaching into supervision tree internals by hand.

`info/1` also completes the graceful-drain story at deploy time without stopping the server:

```elixir
:ok = ThousandIsland.suspend(server_pid)
# poll until existing connections finish up
{:ok, %{active_connections: 0}} = ThousandIsland.info(server_pid)
```

This is Ranch's documented draining pattern (`suspend_listener` then `wait_for_connections`) expressed with one composable read-side primitive instead of a dedicated blocking API.

## Standards and prior art

No wire standard applies; the prior art is Ranch's `get_status`, `info` and `procs` manual pages, plus the general BEAM norm that supervisors are inspectable (`Supervisor.count_children/1`, `DynamicSupervisor.count_children/1`). The implementation is built entirely from those public counting functions.

## Design rationale

Both functions are read-only walks of the existing supervision tree, built from the same helpers `connection_pids/1` already uses, so they inherit the same well-understood semantics (and the same honest caveat, which the docs state: counts are racy by nature in the face of concurrent connects and disconnects).

`status/1` derives suspension from the same source of truth `suspend/1` manipulates, the listener child of the server supervisor. No new state is introduced anywhere, which keeps the functions correct under supervisor restarts by construction.

`active_connections` sums `DynamicSupervisor.count_children/1` across acceptor supervisors rather than collecting pids, so its cost is proportional to `num_acceptors`, not to the number of live connections. The docs position `info/1` as a human-timescale API (health checks, consoles, periodic gauges), the same caveat Ranch's `info` carries.

Naming: `status/1` rather than Ranch's `get_status` because bare nouns are the Elixir convention (`listener_info/1` set the precedent in this codebase). The map returned by `info/1` is deliberately small; `handler_module`, acceptors, and per-acceptor breakdowns can be added later without breaking anyone, whereas removing keys cannot.

## Performance

Zero cost on any connection path; no existing code changes, only additions. The walk itself is a handful of `Supervisor.which_children/1` calls plus one `count_children` per acceptor (100 by default), which is microseconds-scale and only runs when explicitly called. A telemetry-based counter was considered and rejected: it would add per-connection bookkeeping on the hot path to optimize a cold read, which is the wrong side of the trade for this codebase.

## Tests

Two new tests in `server_test.exs`: one drives the full suspend/resume lifecycle and asserts `status/1` tracks it, including that a connection accepted before suspension stays alive and visible (`active_connections: 1` while `:suspended`, `local_info: nil`); the other asserts `local_info` matches the listening port and that `active_connections` tracks 0 -> 2 -> 0 as clients connect and disconnect.