### PR TITLE
Handler performance: reset the read timer lazily instead of on every message

### DIFF
--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -425,7 +425,10 @@ defmodule ThousandIsland.Handler do
       end
 
       def handle_info(:read_timeout, {%ThousandIsland.Socket{} = socket, state}) do
-        {:stop, {:shutdown, :read_timeout}, {socket, state}}
+        case ThousandIsland.Handler.check_read_deadline(socket) do
+          {:timeout, socket} -> {:stop, {:shutdown, :read_timeout}, {socket, state}}
+          {:continue, socket} -> {:noreply, {socket, state}}
+        end
       end
 
       @before_compile {ThousandIsland.Handler, :add_handle_info_fallback}
@@ -552,52 +555,93 @@ defmodule ThousandIsland.Handler do
     ThousandIsland.Telemetry.stop_span(socket.span, measurements, metadata)
   end
 
-  defp cancel_read_timer(%{read_timer: nil} = socket), do: socket
+  defp cancel_read_timer(%{read_timer: nil} = socket), do: %{socket | read_deadline: nil}
 
   defp cancel_read_timer(%{read_timer: timer} = socket) do
     _ = Process.cancel_timer(timer)
 
-    # Since we don't cancel timers until the final handle_continuation call in a callback, flush
-    # any :read_timeout message already delivered to the mailbox before we could cancel the timer
+    # Flush any :read_timeout message already delivered to the mailbox before we could cancel
+    # the timer
     receive do
       :read_timeout -> :ok
     after
       0 -> :ok
     end
 
-    %{socket | read_timer: nil}
+    %{socket | read_timer: nil, read_deadline: nil, timer_deadline: nil}
   end
 
-  defp reset_read_timer(socket, :infinity), do: cancel_read_timer(socket)
+  # The read timer is lazily evaluated: the hot path (a callback returning a `:continue` tuple
+  # after every piece of data) only records the new deadline, and the already-armed timer
+  # re-checks that deadline whenever it fires (see `check_read_deadline/1`). This keeps timer
+  # arming and cancellation off of the per-message path; a timer is armed at most once per
+  # timeout interval rather than once per message
+  defp arm_read_timer(socket, :infinity), do: cancel_read_timer(socket)
 
-  defp reset_read_timer(socket, timeout) do
-    %{cancel_read_timer(socket) | read_timer: Process.send_after(self(), :read_timeout, timeout)}
+  defp arm_read_timer(socket, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    cond do
+      is_nil(socket.read_timer) ->
+        timer = Process.send_after(self(), :read_timeout, timeout)
+        %{socket | read_deadline: deadline, read_timer: timer, timer_deadline: deadline}
+
+      socket.timer_deadline <= deadline ->
+        # The armed timer fires at or before the new deadline; when it fires it will re-arm
+        # itself for whatever time then remains
+        %{socket | read_deadline: deadline}
+
+      true ->
+        # The new deadline is sooner than the armed timer would fire; re-arm eagerly
+        socket = cancel_read_timer(socket)
+        timer = Process.send_after(self(), :read_timeout, timeout)
+        %{socket | read_deadline: deadline, read_timer: timer, timer_deadline: deadline}
+    end
+  end
+
+  @doc false
+  # Called when an armed :read_timeout fires. Because arming is lazy, a firing timer is not
+  # necessarily a timeout: data may have moved the deadline forward since the timer was armed
+  @spec check_read_deadline(ThousandIsland.Socket.t()) ::
+          {:timeout, ThousandIsland.Socket.t()} | {:continue, ThousandIsland.Socket.t()}
+  def check_read_deadline(%{read_deadline: nil} = socket) do
+    # The timeout has since been set to :infinity; absorb the stale firing
+    {:continue, %{socket | read_timer: nil, timer_deadline: nil}}
+  end
+
+  def check_read_deadline(socket) do
+    now = System.monotonic_time(:millisecond)
+
+    if now >= socket.read_deadline do
+      {:timeout, socket}
+    else
+      timer = Process.send_after(self(), :read_timeout, socket.read_deadline - now)
+      {:continue, %{socket | read_timer: timer, timer_deadline: socket.read_deadline}}
+    end
   end
 
   @doc false
   def handle_continuation(continuation, socket) do
-    socket = cancel_read_timer(socket)
-
     case continuation do
       {:continue, state} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        socket = reset_read_timer(socket, socket.read_timeout)
+        socket = arm_read_timer(socket, socket.read_timeout)
         {:noreply, {socket, state}}
 
       {:continue, state, {:continue, continue}} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        socket = reset_read_timer(socket, socket.read_timeout)
+        socket = arm_read_timer(socket, socket.read_timeout)
         {:noreply, {socket, state}, {:continue, continue}}
 
       {:continue, state, {:persistent, timeout}} ->
         socket = %{socket | read_timeout: timeout}
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        socket = reset_read_timer(socket, timeout)
+        socket = arm_read_timer(socket, timeout)
         {:noreply, {socket, state}}
 
       {:continue, state, timeout} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        socket = reset_read_timer(socket, timeout)
+        socket = arm_read_timer(socket, timeout)
         {:noreply, {socket, state}}
 
       {:switch_transport, {module, upgrade_opts}, state} ->
@@ -614,12 +658,14 @@ defmodule ThousandIsland.Handler do
         handle_switch_continuation(socket, module, upgrade_opts, state, timeout)
 
       {:close, state} ->
-        {:stop, {:shutdown, :local_closed}, {socket, state}}
+        {:stop, {:shutdown, :local_closed}, {cancel_read_timer(socket), state}}
 
       {:error, :timeout, state} ->
-        {:stop, {:shutdown, :read_timeout}, {socket, state}}
+        {:stop, {:shutdown, :read_timeout}, {cancel_read_timer(socket), state}}
 
       {:error, reason, state} ->
+        socket = cancel_read_timer(socket)
+
         if socket.silent_terminate_on_error do
           {:stop, {:shutdown, {:silent_termination, reason}}, {socket, state}}
         else
@@ -632,7 +678,7 @@ defmodule ThousandIsland.Handler do
     case ThousandIsland.Socket.upgrade(socket, module, upgrade_opts) do
       {:ok, socket} ->
         _ = ThousandIsland.Socket.setopts(socket, active: :once)
-        socket = reset_read_timer(socket, socket.read_timeout)
+        socket = arm_read_timer(socket, socket.read_timeout)
         {:noreply, {socket, state}, timeout_or_continue}
 
       {:error, reason} ->

--- a/lib/thousand_island/socket.ex
+++ b/lib/thousand_island/socket.ex
@@ -12,7 +12,7 @@ defmodule ThousandIsland.Socket do
     :silent_terminate_on_error,
     :span
   ]
-  defstruct @enforce_keys ++ [:read_timer]
+  defstruct @enforce_keys ++ [:read_timer, :read_deadline, :timer_deadline]
 
   @typedoc "A reference to a socket along with metadata describing how to use it"
   @type t :: %__MODULE__{
@@ -21,6 +21,8 @@ defmodule ThousandIsland.Socket do
           read_timeout: timeout(),
           handshake_timeout: timeout(),
           read_timer: reference() | nil,
+          read_deadline: integer() | nil,
+          timer_deadline: integer() | nil,
           silent_terminate_on_error: boolean(),
           span: ThousandIsland.Telemetry.t()
         }

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -1055,6 +1055,88 @@ defmodule ThousandIsland.HandlerTest do
       assert messages =~ "handle_timeout"
     end
 
+    defmodule LongerOneShotTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data("ping", _socket, state) do
+        {:continue, state, 400}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout")
+      end
+    end
+
+    #
+    # Verify a {:continue, state, timeout} override *longer* than the pending
+    # read_timeout is honored in full: the connection must survive past the
+    # point where the originally scheduled timeout would have fired, and must
+    # still time out at the extended deadline
+    #
+    test "a one-shot timeout longer than the pending read_timeout is honored in full" do
+      {:ok, port} = start_handler(LongerOneShotTimeout, read_timeout: 100)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          :gen_tcp.send(client, "ping")
+
+          # Well past the global 100ms read_timeout, the connection must still
+          # be open thanks to the 400ms one-shot override
+          assert :gen_tcp.recv(client, 0, 250) == {:error, :timeout}
+
+          # ...and must still close at the extended deadline
+          assert :gen_tcp.recv(client, 0, 500) == {:error, :closed}
+          Process.sleep(50)
+        end)
+
+      assert messages =~ "handle_timeout"
+    end
+
+    defmodule InfinityOneShotTimeout do
+      use ThousandIsland.Handler
+
+      require Logger
+
+      @impl ThousandIsland.Handler
+      def handle_data("ping", _socket, state) do
+        {:continue, state, :infinity}
+      end
+
+      @impl ThousandIsland.Handler
+      def handle_timeout(_socket, _state) do
+        Logger.error("handle_timeout")
+      end
+    end
+
+    #
+    # Verify a {:continue, state, :infinity} override disables the pending
+    # read_timeout entirely rather than closing when the originally scheduled
+    # timeout would have fired
+    #
+    test "a one-shot :infinity timeout disables the pending read_timeout" do
+      {:ok, port} = start_handler(InfinityOneShotTimeout, read_timeout: 100)
+
+      messages =
+        capture_log(fn ->
+          {:ok, client} = :gen_tcp.connect(:localhost, port, active: false)
+          :gen_tcp.send(client, "ping")
+
+          # Well past the global 100ms read_timeout, the connection must still
+          # be open
+          assert :gen_tcp.recv(client, 0, 400) == {:error, :timeout}
+
+          :gen_tcp.close(client)
+          Process.sleep(50)
+        end)
+
+      refute messages =~ "handle_timeout"
+    end
+
     test "a GenServer :timeout message does not trigger handle_timeout" do
       # Use a long read_timeout so it won't naturally expire during the test
       {:ok, port} = start_handler(GenServerIdleTimeout, read_timeout: 5_000)


### PR DESCRIPTION
#202 gave connections precise network timeout semantics, but the enforcement runs on the hottest path in the library: every `{:continue, ...}` return, meaning every piece of data on every connection, cancels a timer, flushes the mailbox, and arms a fresh one, all to police a deadline that almost never expires. That is per-message cost for a per-idle-period concern, and eprof puts it at roughly 10% of handler CPU on receive-heavy connections, with the mailbox flush scaling with mailbox depth, so the busiest handlers pay the most.

This PR moves the work to where the rare event is: continuations just record the new deadline, and a firing timer checks it, stopping the connection if it has truly expired and re-arming for the remainder if data moved it forward. A timer is armed once per timeout interval instead of once per message. A deadline that moves earlier (a shorter one-shot) still cancels and re-arms eagerly, so nothing ever fires late.

Behaviour is unchanged: `handle_timeout` still fires at last-data-plus-timeout with the same millisecond precision, the one-shot, `{:persistent, timeout}`, and `:infinity` variants all act identically, and the #202 guarantee that local messages never reset the network timeout is untouched. All existing timeout tests pass unmodified. The two tests added here (a one-shot longer than the pending timeout is honored in full, a one-shot `:infinity` disables it) also pass on current main, since they pin behaviour rather than implementation.

On a loopback echo bench (OTP 27.3 / Elixir 1.18.4, medians of interleaved runs) this is worth about +14% on streaming-style traffic and +3% on small keepalive request/response.

`ThousandIsland.Socket` gains two internal fields (`read_deadline`, `timer_deadline`) beside `read_timer`, the same home #202 chose for the timer itself.