### PR TITLE
Fix port 0 with num_listen_sockets: bind every listener to the advertised port

### DIFF
--- a/lib/thousand_island/listener.ex
+++ b/lib/thousand_island/listener.ex
@@ -53,37 +53,51 @@ defmodule ThousandIsland.Listener do
   end
 
   defp start_listen_sockets(%ThousandIsland.ServerConfig{} = server_config) do
-    num_sockets = server_config.num_listen_sockets
+    with {:ok, first_socket} <-
+           server_config.transport_module.listen(
+             server_config.port,
+             server_config.transport_options
+           ) do
+      sockets = [{1, first_socket}]
 
-    sockets =
-      for socket_id <- 1..num_sockets do
-        case server_config.transport_module.listen(
-               server_config.port,
-               server_config.transport_options
-             ) do
-          {:ok, socket} -> {socket_id, socket}
-          {:error, reason} -> throw({:error, reason})
-        end
+      case server_config.transport_module.sockname(first_socket) do
+        {:ok, local_info} ->
+          port = bind_port(local_info, server_config)
+
+          case start_listen_sockets(server_config, port, 2, sockets) do
+            {:ok, sockets} -> {:ok, sockets, local_info}
+            {:error, reason, sockets} -> close_listen_sockets(server_config, sockets, reason)
+          end
+
+        {:error, reason} ->
+          close_listen_sockets(server_config, sockets, reason)
       end
+    end
+  end
 
-    # Get local info from first socket
-    {1, first_socket} = List.keyfind(sockets, 1, 0)
+  defp start_listen_sockets(server_config, _port, next_id, sockets)
+       when next_id > server_config.num_listen_sockets,
+       do: {:ok, Enum.reverse(sockets)}
 
-    case server_config.transport_module.sockname(first_socket) do
-      {:ok, {ip, port}} ->
-        {:ok, sockets, {ip, port}}
+  defp start_listen_sockets(server_config, port, next_id, sockets) do
+    case server_config.transport_module.listen(port, server_config.transport_options) do
+      {:ok, socket} ->
+        start_listen_sockets(server_config, port, next_id + 1, [{next_id, socket} | sockets])
 
       {:error, reason} ->
-        # Cleanup all sockets on error
-        Enum.each(sockets, fn {_, socket} ->
-          server_config.transport_module.close(socket)
-        end)
-
-        {:error, reason}
+        {:error, reason, sockets}
     end
-  catch
-    {:error, reason} ->
-      {:error, reason}
+  end
+
+  # A listener bound to port 0 is assigned a concrete port by the operating system; use it for
+  # the remaining listeners so that every socket is reachable via the advertised port. Non-IP
+  # listeners (Unix domain sockets) have no port to propagate and keep the configured value
+  defp bind_port({_ip, port}, _server_config) when is_integer(port), do: port
+  defp bind_port(_local_info, server_config), do: server_config.port
+
+  defp close_listen_sockets(server_config, sockets, reason) do
+    Enum.each(sockets, fn {_, socket} -> server_config.transport_module.close(socket) end)
+    {:error, reason}
   end
 
   @impl GenServer

--- a/test/thousand_island/socket_reuse_test.exs
+++ b/test/thousand_island/socket_reuse_test.exs
@@ -15,6 +15,41 @@ defmodule ThousandIsland.SocketReuseTest do
 
   # Note: This test may fail on systems without SO_REUSEPORT support
   describe "socket reuse functionality" do
+    test "port zero binds every listener socket to the advertised port" do
+      config = %ThousandIsland.ServerConfig{
+        port: 0,
+        handler_module: EchoHandler,
+        num_listen_sockets: 3,
+        transport_options: [reuseport: true]
+      }
+
+      case ThousandIsland.Listener.init(config) do
+        {:ok, %{listener_sockets: sockets, local_info: local_info}} ->
+          for {_, socket} <- sockets do
+            assert {:ok, ^local_info} = :inet.sockname(socket)
+            :gen_tcp.close(socket)
+          end
+
+        {:stop, reason} when reason in [:eaddrinuse, :enotsup] ->
+          :ok
+      end
+    end
+
+    test "unix domain sockets with multiple listeners still fail cleanly" do
+      path = Path.join(System.tmp_dir!(), "ti_uds_#{System.unique_integer([:positive])}.sock")
+
+      config = %ThousandIsland.ServerConfig{
+        port: 0,
+        handler_module: EchoHandler,
+        num_listen_sockets: 2,
+        transport_options: [ip: {:local, path}, reuseport: true]
+      }
+
+      assert {:stop, :eaddrinuse} = ThousandIsland.Listener.init(config)
+
+      File.rm(path)
+    end
+
     test "creates multiple sockets when reuseport is enabled" do
       config = %ThousandIsland.ServerConfig{
         port: 5004,


### PR DESCRIPTION
This fixes an edge case in the multiple listener socket support introduced in #174.

When `port: 0` is combined with `num_listen_sockets > 1`, each `listen/2` call receives its own ephemeral port from the operating system, but only the first socket's port is advertised through `listener_info/1`. Connections to the advertised port therefore reach just the first listener socket, and the acceptors assigned to the other sockets wait on ports nothing ever connects to. Reproduced on main with three listen sockets:

```
advertised 33793 | actual ports [{1, 33793}, {2, 41517}, {3, 37121}] | reachable 1/3
```

It subtle but the acceptor round-robin always leaves some acceptors on the first socket, so a `port: 0` multi-socket server still accepts connections and passes the existing tests. It just quietly loses the load-spreading that `num_listen_sockets` exists to provide, along with the acceptors assigned to the unreachable sockets.

The fix opens the first listener with the configured port, reads the concrete port the OS assigned, and binds every remaining listener to that port, so the whole reuseport group is reachable through the advertised address:

```
advertised 46049 | actual ports [{1, 46049}, {2, 46049}, {3, 46049}] | reachable 3/3
```

Fixed nonzero ports flow through the same path with the same behaviour as today. Non-IP listeners (Unix domain sockets, whose sockname has no port to propagate) keep the configured value, so their startup behaviour is also unchanged. As a side effect of the restructure, sockets opened before a later bind failure are now closed rather than left to die with the listener process.

Two tests are added: one asserting that with `port: 0` every listener socket reports the advertised address (fails on main, passes here), and one pinning that Unix domain sockets with `num_listen_sockets > 1` keep failing cleanly with `:eaddrinuse`.

Validation: `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` are clean, and the full suite passes.