### PR TITLE
Perf: Reduce the TLS sendfile chunk size from 8 MiB to 1 MiB

### DIFF
--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -45,8 +45,8 @@ defmodule ThousandIsland.Transports.SSL do
 
   @hardcoded_options [mode: :binary, active: false]
 
-  # Default chunk size: 8MB - balances memory usage vs syscall overhead
-  @sendfile_chunk_size 8 * 1024 * 1024
+  # Default chunk size: 1MB - balances memory usage vs send overhead
+  @sendfile_chunk_size 1024 * 1024
 
   @impl ThousandIsland.Transport
   @spec listen(:inet.port_number(), [:ssl.tls_server_option()]) ::


### PR DESCRIPTION
This tunes the chunk size that #176 introduced for the TLS sendfile loop, from 8 MiB down to 1 MiB. The 8 MiB value was an admitted guess at the time (from the #176 discussion: "The default chunk-size is 8MB, for no special reason TBH"), and measurement shows it sits past the point of diminishing returns for throughput while holding an unnecessarily large binary in flight for every transfer.

Measured on OTP 27.3 / TLS 1.3, loopback, page-cached files, medians of interleaved rounds:

* Peak global binary memory during a single 128 MiB TLS sendfile fell from 37.3 MB to 5.7 MB, an 85% reduction. This is the structural win: every concurrent sendfile holds one chunk (plus the TLS layer's working copies), so the saving scales with the number of simultaneous transfers.
* Throughput was never worse and materially better for large transfers: +30% at 128 MiB files (311 to 403 MB/s), noise-level differences at 8 and 32 MiB, and +5% aggregate with three concurrent 32 MiB streams.
* A chunk-size sweep at 128 MiB (8 MiB, 4 MiB, 1 MiB, 256 KiB) put the optimum at about 1 MiB: 311, 360, 403, and 374 MB/s respectively, so the new constant lands on the measured sweet spot rather than another guess.

The chunk size is not observable from outside: TLS records are 16 KiB regardless, the receiver sees the same byte stream, and offsets, lengths, return values, and error handling are all untouched. The existing 256 MiB sendfile test now exercises 256 chunk iterations and passes unchanged.

Validation: `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` are clean, and the full suite passes.

My test results attached:

[tls-sendfile-results.csv](https://github.com/user-attachments/files/31306238/tls-sendfile-results.csv)
