### PR TITLE
Refactor: Separate connection start retries from socket handoff

### DIFF
--- a/lib/thousand_island/connection.ex
+++ b/lib/thousand_island/connection.ex
@@ -30,29 +30,12 @@ defmodule ThousandIsland.Connection do
       |> Supervisor.child_spec(shutdown: server_config.shutdown_timeout)
 
     # Then try to create it
-    do_start(
-      sup_pid,
-      child_spec,
-      raw_socket,
-      server_config,
-      handler_config,
-      acceptor_span,
-      start_time,
-      server_config.max_connections_retry_count
-    )
-  end
-
-  defp do_start(
-         sup_pid,
-         child_spec,
-         raw_socket,
-         server_config,
-         handler_config,
-         acceptor_span,
-         start_time,
-         retries
-       ) do
-    case DynamicSupervisor.start_child(sup_pid, child_spec) do
+    case start_child_with_retry(
+           sup_pid,
+           child_spec,
+           server_config.max_connections_retry_wait,
+           server_config.max_connections_retry_count
+         ) do
       {:ok, pid} ->
         # Since this process owns the socket at this point, it needs to be the
         # one to make this call. connection_pid is sitting and waiting for the
@@ -69,23 +52,6 @@ defmodule ThousandIsland.Connection do
         send(pid, {:thousand_island_ready, raw_socket, handler_config, acceptor_span, start_time})
 
         :ok
-
-      {:error, :max_children} when retries > 0 ->
-        # We're in a tricky spot here; we have a client connection in hand, but no room to put it
-        # into the connection supervisor. We try to wait a maximum number of times to see if any
-        # room opens up before we give up
-        Process.sleep(server_config.max_connections_retry_wait)
-
-        do_start(
-          sup_pid,
-          child_spec,
-          raw_socket,
-          server_config,
-          handler_config,
-          acceptor_span,
-          start_time,
-          retries - 1
-        )
 
       {:error, :max_children} ->
         # We gave up trying to find room for this connection in our supervisor.
@@ -107,6 +73,20 @@ defmodule ThousandIsland.Connection do
         # Handled exactly as above
         _ = handler_config.transport_module.close(raw_socket)
         {:error, {:spawn_error, other}}
+    end
+  end
+
+  defp start_child_with_retry(sup_pid, child_spec, retry_wait, retries) do
+    case DynamicSupervisor.start_child(sup_pid, child_spec) do
+      {:error, :max_children} when retries > 0 ->
+        # We're in a tricky spot here; we have a client connection in hand, but no room to put it
+        # into the connection supervisor. We try to wait a maximum number of times to see if any
+        # room opens up before we give up
+        Process.sleep(retry_wait)
+        start_child_with_retry(sup_pid, child_spec, retry_wait, retries - 1)
+
+      result ->
+        result
     end
   end
 end


### PR DESCRIPTION
- Move `:max_children` retry behavior into `start_child_with_retry/4`.
- Keep socket ownership transfer, connection startup, telemetry, and terminal cleanup in `start/5`.
- Reduce the connection-start implementation by 20 lines.

## Why

The old recursive helper carried the socket, server config, handler config, telemetry span, and start timestamp through every retry even though retries only concern admission to the dynamic supervisor. Separating those concerns makes the success and cleanup paths visible in one place and gives the retry loop only the four values it uses.

## Behavior and performance

Behavior is unchanged:

- A retry count of `n` still allows `n + 1` start attempts.
- The same wait is used between `:max_children` responses.
- Intermediate retries do not close the accepted socket.
- The final `:max_children` response still closes the socket and returns `{:error, :too_many_connections}`.
- Other child-start results, socket handoff, telemetry, and cleanup are unchanged.

The successful path has the same private helper call and one supervisor start operation as before. The retry path performs the same sleeps and supervisor calls.

## Verification

Verified against thousand_island `main` at `8f04692` with Erlang/OTP 27.3 and Elixir 1.18.4:

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- Full suite: 118 tests pass (the suite's two IPv6 bare-option tests need an IPv6-capable host)
- `mix credo --strict` passes; the combined five-PR tree also passes `mix dialyzer` with no issues