### PR TITLE
Refactor: Consolidate supervisor lifecycle helpers

### DIFF
--- a/lib/thousand_island/acceptor_pool_supervisor.ex
+++ b/lib/thousand_island/acceptor_pool_supervisor.ex
@@ -19,19 +19,15 @@ defmodule ThousandIsland.AcceptorPoolSupervisor do
   end
 
   @spec suspend(Supervisor.supervisor()) :: :ok | :error
-  def suspend(pid) do
-    pid
-    |> acceptor_supervisor_pids()
-    |> Enum.map(&ThousandIsland.AcceptorSupervisor.suspend/1)
-    |> Enum.all?(&(&1 == :ok))
-    |> if(do: :ok, else: :error)
-  end
+  def suspend(pid), do: update_acceptors(pid, &ThousandIsland.AcceptorSupervisor.suspend/1)
 
   @spec resume(Supervisor.supervisor()) :: :ok | :error
-  def resume(pid) do
+  def resume(pid), do: update_acceptors(pid, &ThousandIsland.AcceptorSupervisor.resume/1)
+
+  defp update_acceptors(pid, operation) do
     pid
     |> acceptor_supervisor_pids()
-    |> Enum.map(&ThousandIsland.AcceptorSupervisor.resume/1)
+    |> Enum.map(operation)
     |> Enum.all?(&(&1 == :ok))
     |> if(do: :ok, else: :error)
   end

--- a/lib/thousand_island/server.ex
+++ b/lib/thousand_island/server.ex
@@ -9,29 +9,21 @@ defmodule ThousandIsland.Server do
   end
 
   @spec listener_pid(Supervisor.supervisor()) :: pid() | nil
-  def listener_pid(supervisor) do
-    supervisor
-    |> Supervisor.which_children()
-    |> Enum.find_value(fn
-      {:listener, listener_pid, _, _} when is_pid(listener_pid) ->
-        listener_pid
-
-      _ ->
-        false
-    end)
-  end
+  def listener_pid(supervisor), do: child_pid(supervisor, :listener)
 
   @spec acceptor_pool_supervisor_pid(Supervisor.supervisor()) :: pid() | nil
-  def acceptor_pool_supervisor_pid(supervisor) do
+  def acceptor_pool_supervisor_pid(supervisor),
+    do: child_pid(supervisor, :acceptor_pool_supervisor)
+
+  defp child_pid(supervisor, child_id) do
     supervisor
     |> Supervisor.which_children()
     |> Enum.find_value(fn
-      {:acceptor_pool_supervisor, acceptor_pool_sup_pid, _, _}
-      when is_pid(acceptor_pool_sup_pid) ->
-        acceptor_pool_sup_pid
+      {^child_id, child_pid, _, _} when is_pid(child_pid) ->
+        child_pid
 
       _ ->
-        false
+        nil
     end)
   end
 


### PR DESCRIPTION
During me reading the code, I noticed something that could be simplified. Claude helped with desc.

- Add one private child lookup helper for the listener and acceptor-pool supervisor.
- Add one private acceptor update helper for suspend and resume operations.
- Reduce the two supervisor modules by 12 lines.

## Why

The server contained two copies of the same `Supervisor.which_children/1` search, differing only by child ID. The acceptor pool contained two copies of the same traversal and result aggregation, differing only by the operation applied to each acceptor supervisor.

Naming those two common operations removes duplication while keeping the public functions small and descriptive.

## Behavior and performance

- Child lookup still returns the matching PID or `nil`.
- Suspend and resume still visit every acceptor supervisor before aggregating results.
- `Enum.map/2` is intentionally retained before `Enum.all?/2`, so one failure does not prevent the operation from being attempted on later acceptors.
- The number and order of supervisor calls are unchanged.