### PR TITLE
Refactor: Share listener option resolution across transports

### DIFF
--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -8,6 +8,15 @@ defmodule ThousandIsland.Transport do
   as described in `ThousandIsland`.
   """
 
+  @required_options [mode: :binary, active: false]
+  @default_options [
+    backlog: 1024,
+    nodelay: true,
+    send_timeout: 30_000,
+    send_timeout_close: true,
+    reuseaddr: true
+  ]
+
   @typedoc "A listener socket used to wait for connections"
   @type listener_socket() :: :inet.socket() | :ssl.sslsocket()
 
@@ -100,6 +109,16 @@ defmodule ThousandIsland.Transport do
   @typedoc "The return value from a negotiated_protocol/1 call"
   @type on_negotiated_protocol() ::
           {:ok, binary()} | {:error, :protocol_not_negotiated | :closed}
+
+  @doc false
+  @spec resolve_options(list()) :: list()
+  def resolve_options(user_options) do
+    # We can't use Keyword functions here because the Erlang transports accept bare options
+    Enum.uniq_by(@required_options ++ user_options ++ @default_options, fn
+      {key, _} when is_atom(key) -> key
+      key when is_atom(key) -> key
+    end)
+  end
 
   @doc """
   Create and return a listener socket bound to the given port and configured per

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -43,8 +43,6 @@ defmodule ThousandIsland.Transports.SSL do
 
   @behaviour ThousandIsland.Transport
 
-  @hardcoded_options [mode: :binary, active: false]
-
   # Default chunk size: 1MB - balances memory usage vs send overhead
   @sendfile_chunk_size 1024 * 1024
 
@@ -52,23 +50,7 @@ defmodule ThousandIsland.Transports.SSL do
   @spec listen(:inet.port_number(), [:ssl.tls_server_option()]) ::
           ThousandIsland.Transport.on_listen()
   def listen(port, user_options) do
-    default_options = [
-      backlog: 1024,
-      nodelay: true,
-      send_timeout: 30_000,
-      send_timeout_close: true,
-      reuseaddr: true
-    ]
-
-    # We can't use Keyword functions here because :ssl accepts non-keyword style options
-    resolved_options =
-      Enum.uniq_by(
-        @hardcoded_options ++ user_options ++ default_options,
-        fn
-          {key, _} when is_atom(key) -> key
-          key when is_atom(key) -> key
-        end
-      )
+    resolved_options = ThousandIsland.Transport.resolve_options(user_options)
 
     if not Enum.any?(
          [:certs_keys, :keyfile, :key, :sni_hosts, :sni_fun],

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -41,29 +41,11 @@ defmodule ThousandIsland.Transports.TCP do
 
   @behaviour ThousandIsland.Transport
 
-  @hardcoded_options [mode: :binary, active: false]
-
   @impl ThousandIsland.Transport
   @spec listen(:inet.port_number(), [:inet.inet_backend() | :gen_tcp.listen_option()]) ::
           ThousandIsland.Transport.on_listen()
   def listen(port, user_options) do
-    default_options = [
-      backlog: 1024,
-      nodelay: true,
-      send_timeout: 30_000,
-      send_timeout_close: true,
-      reuseaddr: true
-    ]
-
-    # We can't use Keyword functions here because :gen_tcp accepts non-keyword style options
-    resolved_options =
-      Enum.uniq_by(
-        @hardcoded_options ++ user_options ++ default_options,
-        fn
-          {key, _} when is_atom(key) -> key
-          key when is_atom(key) -> key
-        end
-      )
+    resolved_options = ThousandIsland.Transport.resolve_options(user_options)
 
     # `inet_backend`, if present, needs to be the first option
     sorted_options =


### PR DESCRIPTION
During me reading the code, I noticed something that could be simplified. Claude helped with desc.

- Move the shared required and default listener options to `ThousandIsland.Transport`.
- Add one hidden option resolver used by TCP and SSL.
- Reduce the transport implementations by 17 lines.

## Why

TCP and SSL independently defined the same required options, the same five defaults, and the same first-occurrence option resolution. Keeping that policy in one place makes precedence explicit and prevents the transports from drifting.

## Behavior and performance

- Precedence remains required options, then user options, then defaults.
- The first occurrence of each option key still wins.
- Bare Erlang transport options remain supported.
- TCP still moves `inet_backend` to the first position after resolution.
- SSL still performs the same certificate and key validation after resolution.

Resolution runs once when a listener starts. The extra remote function call is outside the per-connection path and has no meaningful performance effect.