### PR TITLE
Refactor: Simplify shutdown listener state

### DIFF
--- a/lib/thousand_island/shutdown_listener.ex
+++ b/lib/thousand_island/shutdown_listener.ex
@@ -7,10 +7,7 @@ defmodule ThousandIsland.ShutdownListener do
 
   use GenServer
 
-  @type state :: %{
-          optional(:server_pid) => pid(),
-          optional(:listener_pid) => pid() | nil
-        }
+  @type state :: pid() | nil
 
   @doc false
   @spec start_link({pid(), any()}) :: :ignore | {:error, any} | {:ok, pid}
@@ -20,26 +17,26 @@ defmodule ThousandIsland.ShutdownListener do
 
   @doc false
   @impl GenServer
-  @spec init({pid(), any()}) :: {:ok, state, {:continue, :setup_listener_pid}}
+  @spec init({pid(), any()}) ::
+          {:ok, state, {:continue, {:setup_listener_pid, server_pid :: pid()}}}
   def init({server_pid, key}) do
     Process.flag(:trap_exit, true)
     ThousandIsland.ProcessLabel.set(:shutdown_listener, key)
-    {:ok, %{server_pid: server_pid}, {:continue, :setup_listener_pid}}
+    {:ok, nil, {:continue, {:setup_listener_pid, server_pid}}}
   end
 
   @doc false
   @impl GenServer
-  @spec handle_continue(:setup_listener_pid, state) :: {:noreply, state}
-  def handle_continue(:setup_listener_pid, %{server_pid: server_pid}) do
-    listener_pid = ThousandIsland.Server.listener_pid(server_pid)
-    {:noreply, %{listener_pid: listener_pid}}
+  @spec handle_continue({:setup_listener_pid, pid()}, state) :: {:noreply, state}
+  def handle_continue({:setup_listener_pid, server_pid}, nil) do
+    {:noreply, ThousandIsland.Server.listener_pid(server_pid)}
   end
 
   @doc false
   @impl GenServer
   @spec terminate(reason, state) :: :ok
         when reason: :normal | :shutdown | {:shutdown, term} | term
-  def terminate(_reason, %{listener_pid: listener_pid}) do
+  def terminate(_reason, listener_pid) when is_pid(listener_pid) do
     ThousandIsland.Listener.stop(listener_pid)
   end
 

--- a/test/thousand_island/shutdown_listener_test.exs
+++ b/test/thousand_island/shutdown_listener_test.exs
@@ -1,0 +1,13 @@
+defmodule ThousandIsland.ShutdownListenerTest do
+  use ExUnit.Case, async: true
+
+  test "shuts down cleanly when the server has no listener child" do
+    Process.flag(:trap_exit, true)
+    {:ok, supervisor_pid} = Supervisor.start_link([], strategy: :one_for_one)
+
+    {:ok, pid} = ThousandIsland.ShutdownListener.start_link({supervisor_pid, "test"})
+
+    :ok = GenServer.stop(pid, :shutdown)
+    assert_receive {:EXIT, ^pid, :shutdown}
+  end
+end


### PR DESCRIPTION
During me reading the code, I noticed something that could be simplified. Claude helped with desc & test cases.


- Replace the partial map state with `pid() | nil`.
- Carry the server PID in the setup continuation instead of storing it temporarily.
- Keep termination focused on stopping a resolved listener PID.

## Why

The process has two short phases: before listener lookup and after listener lookup. A map with optional `server_pid` and `listener_pid` keys permits more shapes than the process uses. Modeling the actual state as `nil` or the listener PID makes the lifecycle direct and removes transitional map construction.

## Behavior and performance

- Listener lookup still occurs in `handle_continue/2`, after process initialization.
- A resolved listener is still stopped from `terminate/2`.
- A missing or unresolved listener now terminates as an explicit no-op. Previously a `nil` listener PID reached `ThousandIsland.Listener.stop/1` from `terminate/2` and raised; the `is_pid/1` guard routes that case to the existing catch-all clause instead.
- Process labeling and exit trapping are unchanged.

The change removes map allocations from this one-time lifecycle path. It does not affect connection handling.

## Tests

A new test starts a shutdown listener against a supervisor that has no listener child and stops it with reason `:shutdown`. On current `main` this crashes inside `terminate/2` (`ThousandIsland.Listener.stop/1` is called with `nil`); with this change the process exits cleanly. The suite's existing shutdown tests continue to cover the normal early-listener-stop path.