### PR TITLE
Fix: Handle socket ownership-transfer errors during connection start

### DIFF
--- a/lib/thousand_island/acceptor.ex
+++ b/lib/thousand_island/acceptor.ex
@@ -98,6 +98,23 @@ defmodule ThousandIsland.Acceptor do
           count + 1
         )
 
+      {:error, {:controlling_process, reason}} ->
+        # The handler was started, but the accepted socket could not be transferred to it.
+        # Connection.start/5 has already closed the socket and terminated the idle handler,
+        # so report a per-connection setup failure and continue accepting.
+        ThousandIsland.Telemetry.span_event(span, :spawn_error, %{
+          error: {:controlling_process, reason}
+        })
+
+        accept(
+          listener_socket,
+          connection_sup_pid,
+          server_config,
+          handler_config,
+          span,
+          count + 1
+        )
+
       {:error, reason} when reason in [:econnaborted, :einval] ->
         ThousandIsland.Telemetry.span_event(span, reason)
 

--- a/lib/thousand_island/connection.ex
+++ b/lib/thousand_island/connection.ex
@@ -1,6 +1,11 @@
 defmodule ThousandIsland.Connection do
   @moduledoc false
 
+  @type start_error() ::
+          :too_many_connections
+          | {:spawn_error, term()}
+          | {:controlling_process, ThousandIsland.Transport.controlling_process_error()}
+
   @spec start(
           Supervisor.supervisor(),
           ThousandIsland.Transport.socket(),
@@ -8,8 +13,7 @@ defmodule ThousandIsland.Connection do
           ThousandIsland.HandlerConfig.t(),
           ThousandIsland.Telemetry.t()
         ) ::
-          :ok
-          | {:error, :too_many_connections | {:spawn_error, term}}
+          :ok | {:error, start_error()}
   def start(
         sup_pid,
         raw_socket,
@@ -39,19 +43,29 @@ defmodule ThousandIsland.Connection do
       {:ok, pid} ->
         # Since this process owns the socket at this point, it needs to be the
         # one to make this call. connection_pid is sitting and waiting for the
-        # word from us to start processing, in order to ensure that we've made
-        # the following call. Note that we purposefully do not match on the
-        # return from this function; if there's an error the connection process
-        # will see it, but it's no longer our problem if that's the case
-        _ = handler_config.transport_module.controlling_process(raw_socket, pid)
+        # word from us to start processing, in order to ensure that this call
+        # has succeeded before it receives the ready message.
+        case handler_config.transport_module.controlling_process(raw_socket, pid) do
+          :ok ->
+            # Now that we have transferred ownership over to the new process, send a message to the
+            # new process with all the info it needs to start working with the socket (note that the
+            # new process will still need to handshake with the remote end). handler_config was
+            # pre-created by the acceptor to avoid Map.take on every connection.
+            send(
+              pid,
+              {:thousand_island_ready, raw_socket, handler_config, acceptor_span, start_time}
+            )
 
-        # Now that we have transferred ownership over to the new process, send a message to the
-        # new process with all the info it needs to start working with the socket (note that the
-        # new process will still need to handshake with the remote end). handler_config was
-        # pre-created by the acceptor to avoid Map.take on every connection.
-        send(pid, {:thousand_island_ready, raw_socket, handler_config, acceptor_span, start_time})
+            :ok
 
-        :ok
+          {:error, reason} ->
+            # Ownership remains with this process when the transfer fails. Close from here, then
+            # terminate the idle handler as well; terminating it also closes the socket if a custom
+            # transport transferred ownership despite returning an error.
+            _ = handler_config.transport_module.close(raw_socket)
+            _ = DynamicSupervisor.terminate_child(sup_pid, pid)
+            {:error, {:controlling_process, reason}}
+        end
 
       {:error, :max_children} ->
         # We gave up trying to find room for this connection in our supervisor.

--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -60,8 +60,11 @@ defmodule ThousandIsland.Transport do
   @type on_accept_tcp_error() :: :closed | :system_limit | :inet.posix()
   @type on_accept_ssl_error() :: :closed | :timeout | :ssl.error_alert()
 
+  @typedoc "An error returned from a controlling_process/2 call"
+  @type controlling_process_error() :: :closed | :not_owner | :badarg | :inet.posix()
+
   @typedoc "The return value from a controlling_process/2 call"
-  @type on_controlling_process() :: :ok | {:error, :closed | :not_owner | :badarg | :inet.posix()}
+  @type on_controlling_process() :: :ok | {:error, controlling_process_error()}
 
   @typedoc "The return value from a handshake/1 call"
   @type on_handshake() :: {:ok, socket()} | {:error, on_handshake_ssl_error()}

--- a/test/thousand_island/acceptor_test.exs
+++ b/test/thousand_island/acceptor_test.exs
@@ -12,6 +12,9 @@ defmodule ThousandIsland.AcceptorTest do
 
     def set_accept_results(key, results), do: :persistent_term.put({__MODULE__, key}, results)
 
+    def set_controlling_process_results(key, results),
+      do: :persistent_term.put({__MODULE__, key, :controlling_process}, results)
+
     @impl true
     def listen(port, _opts),
       do: :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true])
@@ -36,7 +39,19 @@ defmodule ThousandIsland.AcceptorTest do
     @impl true
     def upgrade(_socket, _opts), do: {:error, :unsupported_upgrade}
     @impl true
-    def controlling_process(socket, pid), do: :gen_tcp.controlling_process(socket, pid)
+    def controlling_process(socket, pid) do
+      key = :persistent_term.get({__MODULE__, :key})
+
+      case :persistent_term.get({__MODULE__, key, :controlling_process}, []) do
+        [reason | rest] ->
+          :persistent_term.put({__MODULE__, key, :controlling_process}, rest)
+          {:error, reason}
+
+        [] ->
+          :gen_tcp.controlling_process(socket, pid)
+      end
+    end
+
     @impl true
     def recv(socket, length, timeout), do: :gen_tcp.recv(socket, length, timeout)
     @impl true
@@ -309,5 +324,44 @@ defmodule ThousandIsland.AcceptorTest do
 
     assert measurements ~> %{monotonic_time: integer(), error: :intentional_init_failure}
     assert metadata ~> %{handler: FailInitHandler, telemetry_span_context: reference()}
+  end
+
+  test "an ownership transfer failure is reported and the acceptor serves the next connection" do
+    on_exit(TelemetryHelpers.attach_all_events(Echo))
+
+    key = make_ref()
+    :persistent_term.put({FlakyTransport, :key}, key)
+    FlakyTransport.set_accept_results(key, [])
+    FlakyTransport.set_controlling_process_results(key, [:badarg])
+
+    {:ok, server_pid} =
+      start_supervised(
+        {ThousandIsland,
+         port: 0, handler_module: Echo, transport_module: FlakyTransport, num_acceptors: 1}
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
+    acceptors_before = acceptor_pids(server_pid)
+
+    {:ok, rejected} = :gen_tcp.connect(:localhost, port, [:binary, active: false], 1_000)
+    assert {:error, :closed} = :gen_tcp.recv(rejected, 0, 1_000)
+    :ok = :gen_tcp.close(rejected)
+
+    assert_receive {:telemetry, [:thousand_island, :acceptor, :spawn_error], measurements,
+                    metadata},
+                   1_000
+
+    assert measurements
+           ~> %{monotonic_time: integer(), error: {:controlling_process, :badarg}}
+
+    assert metadata ~> %{handler: Echo, telemetry_span_context: reference()}
+
+    {:ok, accepted} = :gen_tcp.connect(:localhost, port, [:binary, active: false], 1_000)
+    :ok = :gen_tcp.send(accepted, "NEXT")
+    assert {:ok, "NEXT"} = :gen_tcp.recv(accepted, 0, 1_000)
+
+    assert acceptor_pids(server_pid) == acceptors_before
+    assert Process.alive?(server_pid)
+    :ok = :gen_tcp.close(accepted)
   end
 end

--- a/test/thousand_island/connection_test.exs
+++ b/test/thousand_island/connection_test.exs
@@ -1,0 +1,120 @@
+defmodule ThousandIsland.ConnectionTest do
+  use ExUnit.Case, async: true
+
+  defmodule OwnershipErrorTransport do
+    @behaviour ThousandIsland.Transport
+
+    @impl true
+    def controlling_process(socket, pid) do
+      Kernel.send(socket.test_pid, {:controlling_process, socket.ref, pid})
+      {:error, socket.reason}
+    end
+
+    @impl true
+    def close(socket) do
+      Kernel.send(socket.test_pid, {:socket_closed, socket.ref})
+      :ok
+    end
+
+    @impl true
+    def listen(_port, _options), do: {:error, :enotsup}
+    @impl true
+    def accept(_listener), do: {:error, :enotsup}
+    @impl true
+    def handshake(socket), do: {:ok, socket}
+    @impl true
+    def upgrade(_socket, _options), do: {:error, :unsupported_upgrade}
+    @impl true
+    def recv(_socket, _length, _timeout), do: {:error, :enotsup}
+    @impl true
+    def send(_socket, _data), do: {:error, :enotsup}
+    @impl true
+    def sendfile(_socket, _filename, _offset, _length), do: {:error, :enotsup}
+    @impl true
+    def getopts(_socket, _options), do: {:error, :enotsup}
+    @impl true
+    def setopts(_socket, _options), do: {:error, :enotsup}
+    @impl true
+    def shutdown(_socket, _way), do: {:error, :enotsup}
+    @impl true
+    def sockname(_socket), do: {:error, :enotsup}
+    @impl true
+    def peername(_socket), do: {:error, :enotsup}
+    @impl true
+    def peercert(_socket), do: {:error, :not_secure}
+    @impl true
+    def secure?, do: false
+    @impl true
+    def getstat(_socket), do: {:error, :enotsup}
+    @impl true
+    def negotiated_protocol(_socket), do: {:error, :protocol_not_negotiated}
+    @impl true
+    def connection_information(_socket), do: {:error, :not_secure}
+  end
+
+  defmodule WaitingHandler do
+    use GenServer, restart: :temporary
+
+    def start_link({test_pid, genserver_options}) do
+      GenServer.start_link(__MODULE__, test_pid, genserver_options)
+    end
+
+    @impl true
+    def init(test_pid) do
+      Process.flag(:trap_exit, true)
+      send(test_pid, {:handler_started, self()})
+      {:ok, test_pid}
+    end
+
+    @impl true
+    def handle_info({:thousand_island_ready, _, _, _, _}, test_pid) do
+      send(test_pid, {:handler_ready, self()})
+      {:noreply, test_pid}
+    end
+
+    @impl true
+    def terminate(reason, test_pid) do
+      send(test_pid, {:handler_terminated, self(), reason})
+      :ok
+    end
+  end
+
+  test "an ownership transfer error closes the socket and terminates the idle handler" do
+    supervisor = start_supervised!({DynamicSupervisor, strategy: :one_for_one})
+
+    server_config = %ThousandIsland.ServerConfig{
+      handler_module: WaitingHandler,
+      handler_options: self(),
+      shutdown_timeout: 1_000
+    }
+
+    handler_config = %ThousandIsland.HandlerConfig{
+      handler_module: WaitingHandler,
+      transport_module: OwnershipErrorTransport,
+      read_timeout: 1_000,
+      handshake_timeout: 1_000,
+      silent_terminate_on_error: false
+    }
+
+    socket_ref = make_ref()
+    raw_socket = %{test_pid: self(), ref: socket_ref, reason: :badarg}
+
+    assert {:error, {:controlling_process, :badarg}} =
+             ThousandIsland.Connection.start(
+               supervisor,
+               raw_socket,
+               server_config,
+               handler_config,
+               make_ref()
+             )
+
+    assert_receive {:handler_started, handler_pid}
+    assert_receive {:controlling_process, ^socket_ref, ^handler_pid}
+    assert_receive {:socket_closed, ^socket_ref}
+    assert_receive {:handler_terminated, ^handler_pid, :shutdown}
+    refute_receive {:handler_ready, ^handler_pid}
+
+    refute Process.alive?(handler_pid)
+    assert DynamicSupervisor.which_children(supervisor) == []
+  end
+end

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -556,6 +556,8 @@ defmodule ThousandIsland.ServerTest do
     else
       @tag capture_log: true
       test "it should error if a certificate is not found (pre-OTP-28.1)" do
+        on_exit(TelemetryHelpers.attach_all_events(Error))
+
         {:ok, server_pid, port} =
           start_handler(Error,
             handler_options: [test_pid: self()],
@@ -578,7 +580,36 @@ defmodule ThousandIsland.ServerTest do
 
         ThousandIsland.stop(server_pid)
 
-        assert_received {:options, {:certfile, _, _}}
+        # Depending on whether the peer closes before socket ownership is transferred, the
+        # certificate error is observed either by the handler or while setting up the connection.
+        # Both paths must surface an error without activating a non-owning handler.
+        result =
+          receive do
+            {:options, {:certfile, _, _}} ->
+              :handler_error
+
+            {:telemetry, [:thousand_island, :acceptor, :spawn_error], measurements, metadata} ->
+              {:ownership_error, measurements, metadata}
+          after
+            1_000 -> :timeout
+          end
+
+        case result do
+          :handler_error ->
+            :ok
+
+          {:ownership_error, measurements, metadata} ->
+            assert measurements
+                   ~> %{
+                     monotonic_time: integer(),
+                     error: {:controlling_process, atom()}
+                   }
+
+            assert metadata ~> %{handler: Error, telemetry_span_context: reference()}
+
+          :timeout ->
+            flunk("expected the certificate or ownership-transfer error to be reported")
+        end
       end
     end
 


### PR DESCRIPTION
Note: I asked Claude to specifically look for spec non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

- Check the result of the transport's `controlling_process/2` callback before activating a newly spawned handler.
- On ownership-transfer failure, close the accepted socket, terminate the idle handler child, and return a typed `{:controlling_process, reason}` error.
- Keep the acceptor alive for this per-connection setup failure and emit the existing `:spawn_error` telemetry event with the error attached.
- Add a deterministic regression test backed by a custom transport proving cleanup occurs and the handler never receives the ready message, plus a server-level test that injects the failure through a live acceptor.

## Non-conformance

**The rule.** Both OTP transports define `controlling_process/2` as returning `:ok | {:error, reason}`: [`gen_tcp:controlling_process/2`](https://www.erlang.org/doc/apps/kernel/gen_tcp.html#controlling_process-2) and [`ssl:controlling_process/2`](https://www.erlang.org/doc/apps/ssl/ssl.html#controlling_process-2), the latter additionally requiring the caller to be the current owner. Ownership is not bookkeeping: OTP delivers an active-mode socket's data and closure messages to its controlling process, so this transfer is the step that makes the spawned handler the process that will receive the socket's messages.

**What Thousand Island does today.** `ThousandIsland.Connection.start/5` (`lib/thousand_island/connection.ex`) performs the transfer as

```elixir
_ = handler_config.transport_module.controlling_process(raw_socket, pid)
```

deliberately discarding the result. The accompanying comment says that on error "the connection process will see it, but it's no longer our problem". It then sends `:thousand_island_ready` unconditionally.

**What goes wrong.** That comment has it backwards: when the transfer fails, the handler is precisely the process that will never see anything, because it did not become the owner. The handler is activated on a socket it does not own. Depending on the failure reason, it then waits on a socket whose messages OTP delivers to the still-owning process instead, or on a socket that is already closed; either way it is a live handler that cannot receive what it is waiting for until its read timeout expires, and the accepted socket is not cleaned up by the process that still owns it.

**What this PR makes it do.** Check the transfer result. On `{:error, reason}`, close the socket, terminate the idle handler before it is ever told to start, emit the existing `:spawn_error` telemetry event carrying `{:controlling_process, reason}`, return that typed error, and keep the acceptor accepting. On `:ok`, behavior is unchanged.

## Test plan

Verified on Elixir 1.18.4 / Erlang OTP 27.3.4 against current `main`:

- `mix test test/thousand_island/connection_test.exs test/thousand_island/acceptor_test.exs` passes.
- `mix test test/thousand_island/server_test.exs` passes.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` pass.
- The new tests fail on unpatched `main` and pass with this change.

The unit regression uses a custom transport implementing `ThousandIsland.Transport`. It deterministically returns `{:error, :badarg}` from `controlling_process/2` and records each operation, verifying that the socket is closed, the handler terminates with `:shutdown`, no ready message is sent, the child is removed from the dynamic supervisor, and the typed error is returned.

The server-level regression injects the same failure through a live acceptor. It verifies the accepted socket closes, `:spawn_error` telemetry contains `{:controlling_process, :badarg}`, the acceptor process survives, and the next client is accepted and echoed normally.

## Compatibility / risks

- Successful ownership transfers are unchanged.
- A failed transfer now cleans up immediately and is treated as a recoverable per-connection spawn error instead of activating a handler that cannot own the socket.
- The cleanup waits for the handler's configured supervisor shutdown behavior. This occurs only on the ownership-transfer error path and ensures the spawned child is not leaked.
- Existing custom transports are unaffected if they obey the documented `:ok | {:error, reason}` callback contract.
