### PR TITLE
Fix: Emit connection readiness only after handshake success

### DIFF
--- a/lib/thousand_island/handler.ex
+++ b/lib/thousand_island/handler.ex
@@ -387,11 +387,14 @@ defmodule ThousandIsland.Handler do
           )
 
         socket = ThousandIsland.Socket.new(raw_socket, handler_config, connection_span)
-        ThousandIsland.Telemetry.span_event(connection_span, :ready)
 
         case ThousandIsland.Socket.handshake(socket) do
-          {:ok, socket} -> {:noreply, {socket, state}, {:continue, :handle_connection}}
-          {:error, reason} -> {:stop, {:shutdown, {:handshake, reason}}, {socket, state}}
+          {:ok, socket} ->
+            ThousandIsland.Telemetry.span_event(connection_span, :ready)
+            {:noreply, {socket, state}, {:continue, :handle_connection}}
+
+          {:error, reason} ->
+            {:stop, {:shutdown, {:handshake, reason}}, {socket, state}}
         end
       catch
         {:stop, _, _} = stop -> stop

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -1217,16 +1217,21 @@ defmodule ThousandIsland.HandlerTest do
     test "it should send `ready` telemetry event once socket is ready" do
       TelemetryHelpers.attach_all_events(Telemetry.Closer)
 
-      {:ok, port} = start_handler(Telemetry.Closer)
+      {:ok, port} = start_handler(Telemetry.Closer, handler_options: self())
 
       {:ok, _client} = :gen_tcp.connect(:localhost, port, active: false)
 
-      assert_receive {:telemetry, [:thousand_island, :connection, :ready], measurements,
+      assert_receive {:telemetry, [:thousand_island, :connection, first_event], _, _}, 500
+      assert first_event == :start
+
+      assert_receive {:telemetry, [:thousand_island, :connection, second_event], measurements,
                       metadata},
                      500
 
+      assert second_event == :ready
       assert measurements ~> %{monotonic_time: integer()}
       assert metadata ~> %{handler: Telemetry.Closer, telemetry_span_context: reference()}
+      assert_receive :handle_connection, 500
     end
 
     test "it should send `async_recv` telemetry event on async receipt of data" do
@@ -1290,6 +1295,7 @@ defmodule ThousandIsland.HandlerTest do
 
       @impl ThousandIsland.Handler
       def handle_connection(socket, state) do
+        if is_pid(state), do: send(state, :handle_connection)
         ThousandIsland.Socket.send(socket, "HELLO")
         {:close, state}
       end

--- a/test/thousand_island/socket_test.exs
+++ b/test/thousand_island/socket_test.exs
@@ -331,8 +331,10 @@ defmodule ThousandIsland.SocketTest do
 
     @tag capture_log: true
     test "it should close stalled handshakes once handshake_timeout has elapsed", context do
+      TelemetryHelpers.attach_all_events(Error)
+
       server_opts =
-        [handler_options: [test_pid: self()], handshake_timeout: 250] ++ context.server_opts
+        [handler_options: [test_pid: self()], handshake_timeout: 500] ++ context.server_opts
 
       {:ok, server_pid} =
         start_supervised({ThousandIsland, [port: 0, handler_module: Error] ++ server_opts})
@@ -342,7 +344,10 @@ defmodule ThousandIsland.SocketTest do
       # Connect at the TCP level but never start a TLS handshake
       {:ok, client} = :gen_tcp.connect(~c"localhost", port, active: false)
 
+      assert_receive {:telemetry, [:thousand_island, :connection, :start], _, _}, 500
+      refute_receive {:telemetry, [:thousand_island, :connection, :ready], _, _}, 100
       assert_receive {:handle_error, :timeout}, 1000
+      refute_received {:telemetry, [:thousand_island, :connection, :ready], _, _}
 
       # The connection process should be gone and the socket closed underneath the client
       Process.sleep(100)
@@ -353,8 +358,15 @@ defmodule ThousandIsland.SocketTest do
     end
 
     test "it should complete handshakes as normal within handshake_timeout", context do
+      TelemetryHelpers.attach_all_events(Echo)
+
       {:ok, port} = start_handler(Echo, [handshake_timeout: 5_000] ++ context.server_opts)
       {:ok, client} = context.client_mod.connect(~c"localhost", port, context.client_opts)
+
+      assert_receive {:telemetry, [:thousand_island, :connection, first_event], _, _}, 500
+      assert first_event == :start
+      assert_receive {:telemetry, [:thousand_island, :connection, second_event], _, _}, 500
+      assert second_event == :ready
 
       assert context.client_mod.send(client, "HELLO") == :ok
       assert context.client_mod.recv(client, 0) == {:ok, "HELLO"}


### PR DESCRIPTION
Note: I asked Claude to specifically look for spec non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

- Move `[:thousand_island, :connection, :ready]` emission into the successful handshake branch.
- Keep the event before `handle_connection/2` runs.
- Add regression coverage for successful TLS handshakes, stalled handshake timeouts, event ordering, and callback ordering.

## Non-conformance

**The rule.** This one is Thousand Island's own contract. The `ThousandIsland.Telemetry` module documentation defines the event: `[:thousand_island, :connection, :ready]` means "Thousand Island has completed setting up the client connection". The [`ThousandIsland.Handler` lifecycle documentation](https://hexdocs.pm/thousand_island/ThousandIsland.Handler.html) counts the transport handshake, TLS negotiation included, as part of that setup.

**What Thousand Island does today.** In the generated `handle_info({:thousand_island_ready, ...})` clause in `lib/thousand_island/handler.ex`, the event is emitted first and the handshake happens after:

```elixir
ThousandIsland.Telemetry.span_event(connection_span, :ready)

case ThousandIsland.Socket.handshake(socket) do
```

**What goes wrong.** Every accepted TLS connection is announced as ready, including every one whose handshake then fails or times out. A failed handshake produces a span containing `ready` followed by a stop carrying a handshake error, so anything counting `ready` events counts successful setups that never happened, and the event cannot be used for what its documentation says it means.

**What this PR makes it do.** Emit `ready` only in the `{:ok, socket}` branch of the handshake, still before `handle_connection/2` is scheduled. The event ordering for successful connections is unchanged (`start`, then `ready`); failed handshakes now emit no `ready` at all.

## Test plan

Verified on Elixir 1.18.4 / Erlang OTP 27.3.4 against current `main`:

- `mix test test/thousand_island/handler_test.exs test/thousand_island/socket_test.exs` passes.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` pass.
- The new assertions fail on unpatched `main` and pass with this change.

Regression coverage verifies:

- connection events are ordered `start`, then `ready`;
- `ready` is emitted before `handle_connection/2`;
- a successful TLS handshake emits `ready`;
- a stalled TLS handshake emits no `ready` before or after timing out.

## Compatibility / risks

- Plain TCP uses a no-op transport handshake, so its readiness timing changes only by a function return.
- TLS consumers will no longer receive false-positive readiness events for failed or timed-out handshakes.
- Dashboards that treated `ready` as "accepted but not yet handshaken" will see different counts, but that interpretation contradicted the documented contract.