### PR TITLE
Fix: Add system time to telemetry span start measurements

### DIFF
--- a/lib/thousand_island/telemetry.ex
+++ b/lib/thousand_island/telemetry.ex
@@ -15,6 +15,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following measurements:
 
       * `monotonic_time`: The time of this event, in `:native` units
+      * `system_time`: The system time of this event, in `:native` units
 
       This event contains the following metadata:
 
@@ -57,6 +58,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following measurements:
 
       * `monotonic_time`: The time of this event, in `:native` units
+      * `system_time`: The system time of this event, in `:native` units
 
       This event contains the following metadata:
 
@@ -162,6 +164,7 @@ defmodule ThousandIsland.Telemetry do
       This event contains the following measurements:
 
       * `monotonic_time`: The time of this event, in `:native` units
+      * `system_time`: The system time of this event, in `:native` units
 
       This event contains the following metadata:
 
@@ -363,7 +366,11 @@ defmodule ThousandIsland.Telemetry do
   @doc false
   @spec start_span(span_name(), measurements(), metadata()) :: t()
   def start_span(span_name, measurements, metadata) do
-    measurements = Map.put_new_lazy(measurements, :monotonic_time, &monotonic_time/0)
+    measurements =
+      measurements
+      |> Map.put_new_lazy(:monotonic_time, &monotonic_time/0)
+      |> Map.put_new_lazy(:system_time, &system_time/0)
+
     telemetry_span_context = make_ref()
     metadata = Map.put(metadata, :telemetry_span_context, telemetry_span_context)
     _ = event([span_name, :start], measurements, metadata)
@@ -432,6 +439,10 @@ defmodule ThousandIsland.Telemetry do
 
   @spec monotonic_time() :: integer
   defdelegate monotonic_time, to: System
+
+  @doc false
+  @spec system_time() :: integer
+  defdelegate system_time, to: System
 
   defp event(suffix, measurements, metadata) do
     :telemetry.execute([@app_name | suffix], measurements, metadata)

--- a/test/thousand_island/handler_test.exs
+++ b/test/thousand_island/handler_test.exs
@@ -1202,7 +1202,7 @@ defmodule ThousandIsland.HandlerTest do
                       metadata},
                      500
 
-      assert measurements ~> %{monotonic_time: integer()}
+      assert measurements ~> %{monotonic_time: integer(), system_time: integer()}
 
       assert metadata
              ~> %{

--- a/test/thousand_island/listener_test.exs
+++ b/test/thousand_island/listener_test.exs
@@ -98,7 +98,7 @@ defmodule ThousandIsland.ListenerTest do
       assert_receive {:telemetry, [:thousand_island, :listener, :start], measurements, metadata},
                      500
 
-      assert measurements ~> %{monotonic_time: integer()}
+      assert measurements ~> %{monotonic_time: integer(), system_time: integer()}
 
       assert metadata
              ~> %{

--- a/test/thousand_island/server_test.exs
+++ b/test/thousand_island/server_test.exs
@@ -333,7 +333,7 @@ defmodule ThousandIsland.ServerTest do
       assert_receive {:telemetry, [:thousand_island, :listener, :start], measurements, metadata},
                      500
 
-      assert measurements ~> %{monotonic_time: integer()}
+      assert measurements ~> %{monotonic_time: integer(), system_time: integer()}
 
       assert metadata
              ~> %{
@@ -348,7 +348,7 @@ defmodule ThousandIsland.ServerTest do
       assert_receive {:telemetry, [:thousand_island, :acceptor, :start], measurements, metadata},
                      500
 
-      assert measurements ~> %{monotonic_time: integer()}
+      assert measurements ~> %{monotonic_time: integer(), system_time: integer()}
 
       assert metadata
              ~> %{

--- a/test/thousand_island/telemetry_test.exs
+++ b/test/thousand_island/telemetry_test.exs
@@ -1,0 +1,34 @@
+defmodule ThousandIsland.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  alias ThousandIsland.Telemetry
+
+  test "start spans preserve caller-supplied system and monotonic times" do
+    handler_id = make_ref()
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:thousand_island, :connection, :start],
+        &__MODULE__.forward_event/4,
+        self()
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    _span =
+      Telemetry.start_span(
+        :connection,
+        %{monotonic_time: 123, system_time: 456},
+        %{handler: __MODULE__}
+      )
+
+    assert_receive {:telemetry_event, %{monotonic_time: 123, system_time: 456}, metadata}
+    assert metadata.handler == __MODULE__
+    assert is_reference(metadata.telemetry_span_context)
+  end
+
+  def forward_event(_event, measurements, metadata, pid) do
+    send(pid, {:telemetry_event, measurements, metadata})
+  end
+end


### PR DESCRIPTION
Note: I asked Claude to specifically look for spec non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

- Add `system_time` to listener, acceptor, and connection span start measurements.
- Preserve caller-supplied `system_time` and `monotonic_time` values through `Map.put_new_lazy/3`.
- Document the measurement and update start-event regression tests.
- Add a focused test for explicit timestamp preservation.

## Non-conformance

**The rule.** The span convention Thousand Island's telemetry documents itself against specifies two measurements on every span start event: "`system_time => integer(), monotonic_time => integer()`" ([`telemetry.span/3`](https://hexdocs.pm/telemetry/telemetry.html#span/3)).

**What Thousand Island does today.** `ThousandIsland.Telemetry.start_span/3` (`lib/thousand_island/telemetry.ex`) fills in only `monotonic_time`. No listener, acceptor, or connection start event carries `system_time`, although the module documentation presents these pairs as spans.

**What goes wrong.** Monotonic time is meaningful only relative to one runtime instance. Without the conventional wall-clock anchor, consumers cannot place a span start on a calendar timeline, cannot correlate spans across nodes, and cannot line spans up with log timestamps, which is precisely the gap `system_time` exists to close. Generic span-consuming tooling that reads the conventional key finds it missing.

**What this PR makes it do.** `start_span/3` adds `system_time` through `Map.put_new_lazy/3`, so all three span starts carry both conventional measurements, a caller-supplied value for either timestamp is preserved unchanged, and no clock call is made when one is supplied. The event documentation is updated to list the new measurement.

## Test plan

Verified on Elixir 1.18.4 / Erlang OTP 27.3.4 against current `main`:

- `mix test test/thousand_island/telemetry_test.exs test/thousand_island/handler_test.exs test/thousand_island/listener_test.exs test/thousand_island/server_test.exs` passes.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` pass.
- The updated start-event assertions fail on unpatched `main` and pass with this change.

Regression coverage verifies:

- listener, acceptor, and connection start events include integer `system_time` and `monotonic_time` measurements;
- explicitly supplied values for both timestamps are retained unchanged.

## Compatibility / risks

- This is an additive measurement key and does not remove or rename existing event data.
- Telemetry consumers that require an exact measurement map may need to accept the additional key.
- Lazy insertion avoids a system clock call when an internal caller already supplied `system_time`.