### PR TITLE
Docs: Make the HTTP hello-world example follow RFC 1945

### DIFF
--- a/examples/http_hello_world.ex
+++ b/examples/http_hello_world.ex
@@ -1,15 +1,217 @@
 defmodule HTTPHelloWorld do
   @moduledoc """
-  A sample Handler implementation of a simple HTTP Server. Intended to be the
-  simplest thing that can answer a browser request and nothing more. Not even
-  remotely strictly HTTP compliant.
+  A small HTTP/1.0 origin server example implementing a conservative subset of
+  RFC 1945.
+
+  It implements `GET` and `HEAD`, recognizes HTTP/0.9 simple requests, waits for
+  a complete request before responding, and closes each connection after one
+  response. Start it with the default handler options so the initial request
+  buffer is `[]`.
   """
 
   use ThousandIsland.Handler
 
+  @body "Hello, World"
+  @max_request_size 16_384
+  @separators ~c"()<>@,;:\\\"/[]?={} \t"
+  @uri_characters ~c"$-_.+!*'(),;/?:@&="
+
   @impl ThousandIsland.Handler
-  def handle_data(_data, socket, state) do
-    ThousandIsland.Socket.send(socket, "HTTP/1.0 200 OK\r\n\r\nHello, World")
-    {:close, state}
+  def handle_data(data, socket, state) do
+    request = IO.iodata_to_binary([state, data])
+
+    case parse_request(request) do
+      :more ->
+        {:continue, request}
+
+      {:simple, :get} ->
+        ThousandIsland.Socket.send(socket, @body)
+        {:close, request}
+
+      {:full, :get} ->
+        ThousandIsland.Socket.send(socket, response("200 OK", @body, true))
+        {:close, request}
+
+      {:full, :head} ->
+        ThousandIsland.Socket.send(socket, response("200 OK", @body, false))
+        {:close, request}
+
+      {:error, :not_implemented} ->
+        body = "Not Implemented\r\n"
+        ThousandIsland.Socket.send(socket, response("501 Not Implemented", body, true))
+        {:close, request}
+
+      {:error, :bad_request} ->
+        body = "Bad Request\r\n"
+        ThousandIsland.Socket.send(socket, response("400 Bad Request", body, true))
+        {:close, request}
+    end
+  end
+
+  defp parse_request(request) when byte_size(request) > @max_request_size,
+    do: {:error, :bad_request}
+
+  defp parse_request(request) do
+    case :binary.match(request, "\r\n") do
+      :nomatch ->
+        :more
+
+      {line_end, 2} ->
+        request_line = binary_part(request, 0, line_end)
+        parse_request_line(request_line, request, line_end)
+    end
+  end
+
+  defp parse_request_line(request_line, request, line_end) do
+    case request_line |> String.split(" ", trim: true) do
+      ["GET", target] ->
+        if valid_target?(target), do: {:simple, :get}, else: {:error, :bad_request}
+
+      [_method, _target] ->
+        {:error, :bad_request}
+
+      [method, target, "HTTP/1.0"] ->
+        parse_full_request(method, target, request, line_end)
+
+      [_method, _target, "HTTP/" <> _version] ->
+        {:error, :bad_request}
+
+      _ ->
+        {:error, :bad_request}
+    end
+  end
+
+  defp parse_full_request(method, target, request, line_end) do
+    with true <- valid_token?(method),
+         true <- valid_target?(target),
+         {:ok, headers} <- complete_headers(request, line_end),
+         true <- valid_headers?(headers) do
+      case method do
+        "GET" -> {:full, :get}
+        "HEAD" -> {:full, :head}
+        _ -> {:error, :not_implemented}
+      end
+    else
+      :more -> :more
+      _ -> {:error, :bad_request}
+    end
+  end
+
+  defp complete_headers(request, line_end) do
+    case :binary.match(request, "\r\n\r\n") do
+      :nomatch ->
+        :more
+
+      {^line_end, 4} ->
+        {:ok, ""}
+
+      {headers_end, 4} ->
+        headers_start = line_end + 2
+        {:ok, binary_part(request, headers_start, headers_end - headers_start)}
+    end
+  end
+
+  defp valid_headers?(""), do: true
+
+  defp valid_headers?(headers) do
+    headers
+    |> :binary.split("\r\n", [:global])
+    |> Enum.reduce_while(false, fn line, previous_header? ->
+      cond do
+        valid_continuation?(line) and previous_header? ->
+          {:cont, true}
+
+        valid_header?(line) ->
+          {:cont, true}
+
+        true ->
+          {:halt, false}
+      end
+    end)
+  end
+
+  defp valid_continuation?(<<char, value::binary>>) when char in [32, 9],
+    do: valid_field_value?(value)
+
+  defp valid_continuation?(_line), do: false
+
+  defp valid_header?(line) do
+    case :binary.split(line, ":") do
+      [name, value] -> valid_token?(name) and valid_field_value?(value)
+      _ -> false
+    end
+  end
+
+  defp valid_field_value?(value) do
+    value
+    |> :binary.bin_to_list()
+    |> Enum.all?(fn char -> char == 9 or (char >= 32 and char != 127) end)
+  end
+
+  defp valid_token?(value) when byte_size(value) > 0 do
+    value
+    |> :binary.bin_to_list()
+    |> Enum.all?(fn char -> char > 31 and char < 127 and char not in @separators end)
+  end
+
+  defp valid_token?(_value), do: false
+
+  defp valid_target?(<<"/", _::binary>> = target), do: valid_uri_characters?(target)
+
+  defp valid_target?(target) when byte_size(target) > 0 do
+    case :binary.split(target, ":") do
+      [scheme, rest] -> valid_scheme?(scheme) and valid_uri_characters?(rest)
+      _ -> false
+    end
+  end
+
+  defp valid_target?(_target), do: false
+
+  defp valid_scheme?(scheme) when byte_size(scheme) > 0 do
+    scheme
+    |> :binary.bin_to_list()
+    |> Enum.all?(fn char ->
+      (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or
+        (char >= ?0 and char <= ?9) or char in ~c"+-."
+    end)
+  end
+
+  defp valid_scheme?(_scheme), do: false
+
+  defp valid_uri_characters?(<<>>), do: true
+
+  defp valid_uri_characters?(<<"%", high, low, rest::binary>>) do
+    hex_digit?(high) and hex_digit?(low) and valid_uri_characters?(rest)
+  end
+
+  defp valid_uri_characters?(<<char, rest::binary>>) do
+    valid_uri_character?(char) and valid_uri_characters?(rest)
+  end
+
+  defp valid_uri_character?(char) do
+    (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or
+      (char >= ?0 and char <= ?9) or char in @uri_characters
+  end
+
+  defp hex_digit?(char),
+    do:
+      (char >= ?0 and char <= ?9) or (char >= ?A and char <= ?F) or
+        (char >= ?a and char <= ?f)
+
+  defp response(status, body, include_body?) do
+    headers = [
+      "HTTP/1.0 ",
+      status,
+      "\r\n",
+      "Date: ",
+      Calendar.strftime(DateTime.utc_now(), "%a, %d %b %Y %H:%M:%S GMT"),
+      "\r\n",
+      "Content-Type: text/plain; charset=utf-8\r\n",
+      "Content-Length: ",
+      Integer.to_string(byte_size(body)),
+      "\r\n\r\n"
+    ]
+
+    if include_body?, do: [headers, body], else: headers
   end
 end

--- a/test/thousand_island/examples/http_hello_world_test.exs
+++ b/test/thousand_island/examples/http_hello_world_test.exs
@@ -1,0 +1,102 @@
+defmodule ThousandIsland.Examples.HTTPHelloWorldTest do
+  use ExUnit.Case, async: true
+
+  Code.require_file("../../../examples/http_hello_world.ex", __DIR__)
+
+  test "waits for a complete HTTP/1.0 request across TCP chunks" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "GET / HTTP/1.0\r\nHost: example")
+    assert {:error, :timeout} = :gen_tcp.recv(client, 0, 50)
+    assert :ok = :gen_tcp.send(client, ".test\r\n\r\n")
+
+    response = receive_all(client)
+    assert response =~ "HTTP/1.0 200 OK\r\n"
+
+    assert response =~
+             ~r/Date: [A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT\r\n/
+
+    assert response =~ "Content-Type: text/plain; charset=utf-8\r\n"
+    assert response =~ "Content-Length: 12\r\n"
+    assert String.ends_with?(response, "\r\n\r\nHello, World")
+  end
+
+  test "uses a simple response for an HTTP/0.9 simple request" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "GET /\r\n")
+    assert receive_all(client) == "Hello, World"
+  end
+
+  test "does not include an entity body in a HEAD response" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "HEAD / HTTP/1.0\r\n\r\n")
+
+    response = receive_all(client)
+    assert response =~ "HTTP/1.0 200 OK\r\n"
+    assert response =~ "Content-Length: 12\r\n"
+    assert String.ends_with?(response, "\r\n\r\n")
+    refute response =~ "Hello, World"
+  end
+
+  test "returns 400 for a malformed request" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "GET\r\n")
+
+    response = receive_all(client)
+    assert response =~ "HTTP/1.0 400 Bad Request\r\n"
+    assert String.ends_with?(response, "\r\n\r\nBad Request\r\n")
+  end
+
+  test "returns 400 for invalid header values and request targets" do
+    invalid_requests = [
+      "GET / HTTP/1.0\r\nX-Test: a\0b\r\n\r\n",
+      "GET not-a-uri HTTP/1.0\r\n\r\n",
+      <<"GET /", 0xFF, " HTTP/1.0\r\n\r\n">>,
+      "GET /bad%escape HTTP/1.0\r\n\r\n"
+    ]
+
+    for request <- invalid_requests do
+      client = connect()
+      assert :ok = :gen_tcp.send(client, request)
+      assert receive_all(client) =~ "HTTP/1.0 400 Bad Request\r\n"
+    end
+  end
+
+  test "accepts an absolute URI request target" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "GET http://example.test/ HTTP/1.0\r\n\r\n")
+    assert receive_all(client) =~ "HTTP/1.0 200 OK\r\n"
+  end
+
+  test "returns 501 for an unimplemented method" do
+    client = connect()
+    assert :ok = :gen_tcp.send(client, "POST / HTTP/1.0\r\nContent-Length: 0\r\n\r\n")
+
+    response = receive_all(client)
+    assert response =~ "HTTP/1.0 501 Not Implemented\r\n"
+    assert String.ends_with?(response, "\r\n\r\nNot Implemented\r\n")
+  end
+
+  defp connect do
+    server =
+      start_supervised!(
+        {ThousandIsland,
+         [
+           handler_module: HTTPHelloWorld,
+           num_acceptors: 1,
+           port: 0,
+           read_timeout: 1_000
+         ]}
+      )
+
+    {:ok, {_address, port}} = ThousandIsland.listener_info(server)
+    {:ok, client} = :gen_tcp.connect(:localhost, port, [:binary, active: false])
+    client
+  end
+
+  defp receive_all(client, acc \\ "") do
+    case :gen_tcp.recv(client, 0, 1_000) do
+      {:ok, data} -> receive_all(client, acc <> data)
+      {:error, :closed} -> acc
+    end
+  end
+end


### PR DESCRIPTION
Note: I asked Claude to specifically look for spec non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

Replace the intentionally noncompliant one-chunk HTTP responder with a small, self-contained origin server implementing a conservative RFC 1945 subset. It now accumulates fragmented TCP input, parses a complete request, supports HTTP/0.9 `GET`, implements HTTP/1.0 `GET` and `HEAD`, returns meaningful errors, emits entity metadata, and closes after one response. The module explicitly describes itself as a subset rather than claiming to be a general HTTP parser.

## Non-conformance

**The rule.** The example declares itself an HTTP/1.0 server, and RFC 1945 defines what that means on the wire: parse the Request-Line and headers before responding ([section 4.1](https://www.rfc-editor.org/rfc/rfc1945.html#section-4.1) distinguishes simple and full messages, [section 5](https://www.rfc-editor.org/rfc/rfc1945.html#section-5) gives the request grammar, [section 4.2](https://www.rfc-editor.org/rfc/rfc1945.html#section-4.2) constrains field values, and [section 5.1.2](https://www.rfc-editor.org/rfc/rfc1945.html#section-5.1.2) requires an `absoluteURI` or `abs_path` target per [RFC 1808 section 2.2](https://www.rfc-editor.org/rfc/rfc1808.html#section-2.2)); answer an HTTP/0.9 Simple-Request with a Simple-Response; send no entity body for `HEAD` ([section 8.2](https://www.rfc-editor.org/rfc/rfc1945.html#section-8.2)); and use `400` and `501` for malformed and unimplemented requests ([sections 9.4 and 9.5](https://www.rfc-editor.org/rfc/rfc1945.html#section-9.4)). Response metadata (`Date`, `Content-Type`, `Content-Length`, [sections 10.4 through 10.6](https://www.rfc-editor.org/rfc/rfc1945.html#section-10.4)) and close-delimited bodies ([section 7.2.2](https://www.rfc-editor.org/rfc/rfc1945.html#section-7.2.2)) are recommendation-level.

**What the example does today.** `examples/http_hello_world.ex` sends one complete `200 OK` HTTP/1.0 response to the first TCP chunk it receives, whatever that chunk contains.

**What goes wrong,** point by point against the RFC:

- it never parses the Request-Line or waits for the header terminator, so a request split across TCP segments is answered before it arrives;
- an HTTP/0.9 Simple-Request receives a full HTTP/1.0 response, which for HTTP/0.9 clients corrupts the body with status line and headers;
- `HEAD` receives an entity body, which section 8.2 prohibits;
- malformed and unsupported requests receive `200 OK` instead of `400` or `501`;
- the response omits the recommended `Date`, `Content-Type`, and `Content-Length` fields and relies solely on connection close to delimit the entity.

RFC 1945 is Informational rather than an Internet Standard, but it is the wire specification this example names and teaches.

**What this PR makes it do.** The handler becomes a small, deliberately conservative RFC 1945 subset (described under Implementation below): it buffers until the request is complete, distinguishes simple from full requests, implements `GET` and `HEAD` correctly, returns meaningful errors, and emits the recommended metadata, while stating plainly in its own docs that it is teaching code, not a production HTTP server.

## Implementation

- Buffer at most 16 KiB while waiting for the request line and headers.
- Recognize a Simple-Request and return only its Simple-Response body.
- Validate HTTP/1.0 request lines, URI octets and escapes, field names, field values, and folded header continuation.
- Implement `GET` and `HEAD`; return `501` for other valid methods and `400` for malformed input.
- Generate RFC-compatible `Date`, `Content-Type`, and `Content-Length` fields.
- Close after one response, matching normal HTTP/1.0 connection behavior.

This remains deliberately compact teaching code. Production applications should use a maintained HTTP server implementation.

## Test plan

Verified on Elixir 1.18.4 / Erlang OTP 27.3.4 against current `main`:

- Split a valid request across TCP sends and verify there is no early response.
- Verify the HTTP/0.9 response contains no HTTP/1.0 status or headers.
- Verify HEAD reports the GET content length but sends no entity body.
- Verify malformed requests return 400.
- Verify invalid request targets, percent escapes, and control bytes in header values return 400, while an absolute URI is accepted.
- Verify an unimplemented valid method returns 501.
- `mix format --check-formatted` and `mix credo --strict` pass.

## Compatibility / risks

This changes only an example that is excluded from the Hex package. The example now uses its default handler state as a request buffer and intentionally handles one request per connection.