### PR TITLE
Fix: Omit the TCP_NODELAY default for Unix domain listeners

### DIFF
--- a/lib/thousand_island/transport.ex
+++ b/lib/thousand_island/transport.ex
@@ -11,7 +11,6 @@ defmodule ThousandIsland.Transport do
   @required_options [mode: :binary, active: false]
   @default_options [
     backlog: 1024,
-    nodelay: true,
     send_timeout: 30_000,
     send_timeout_close: true,
     reuseaddr: true
@@ -114,10 +113,28 @@ defmodule ThousandIsland.Transport do
   @spec resolve_options(list()) :: list()
   def resolve_options(user_options) do
     # We can't use Keyword functions here because the Erlang transports accept bare options
-    Enum.uniq_by(@required_options ++ user_options ++ @default_options, fn
-      {key, _} when is_atom(key) -> key
-      key when is_atom(key) -> key
-    end)
+    Enum.uniq_by(
+      @required_options ++
+        user_options ++
+        default_nodelay_options(user_options) ++
+        @default_options,
+      fn
+        {key, _} when is_atom(key) -> key
+        key when is_atom(key) -> key
+      end
+    )
+  end
+
+  # `nodelay` is a TCP-specific option, and the default is omitted for Unix domain sockets:
+  # the legacy inet backend ignores the invalid combination, but the socket backend rejects
+  # it, so injecting it breaks Unix domain listeners under `inet_backend: :socket`. An
+  # explicitly supplied `nodelay` value is still passed through unchanged.
+  defp default_nodelay_options(user_options) do
+    local_address? =
+      match?({:local, _}, :proplists.get_value(:ip, user_options)) or
+        match?({:local, _}, :proplists.get_value(:ifaddr, user_options))
+
+    if local_address?, do: [], else: [nodelay: true]
   end
 
   @doc """

--- a/lib/thousand_island/transports/ssl.ex
+++ b/lib/thousand_island/transports/ssl.ex
@@ -28,6 +28,9 @@ defmodule ThousandIsland.Transports.SSL do
   reuseaddr: true
   ```
 
+  The `nodelay` default is omitted for Unix domain sockets, since it is a
+  TCP-specific option.
+
   The following options are required for the proper operation of Thousand Island
   and cannot be overridden:
 

--- a/lib/thousand_island/transports/tcp.ex
+++ b/lib/thousand_island/transports/tcp.ex
@@ -26,6 +26,9 @@ defmodule ThousandIsland.Transports.TCP do
   reuseaddr: true
   ```
 
+  The `nodelay` default is omitted for Unix domain sockets, since it is a
+  TCP-specific option.
+
   The following options are required for the proper operation of Thousand Island
   and cannot be overridden:
 

--- a/test/thousand_island/transport_options_test.exs
+++ b/test/thousand_island/transport_options_test.exs
@@ -1,0 +1,87 @@
+defmodule ThousandIsland.TransportOptionsTest do
+  use ExUnit.Case, async: false
+
+  @certfile Path.expand("../support/cert.pem", __DIR__)
+  @keyfile Path.expand("../support/key.pem", __DIR__)
+
+  test "TCP and SSL omit the nodelay default only for Unix domain sockets" do
+    unix_path =
+      Path.join(
+        System.tmp_dir!(),
+        "thousand_island_#{System.unique_integer([:positive])}.sock"
+      )
+
+    on_exit(fn -> File.rm(unix_path) end)
+
+    for {transport, backend, required_options} <- transports() do
+      [
+        ip_unix_options,
+        ifaddr_unix_options,
+        explicit_ip_options,
+        explicit_ifaddr_options,
+        ip_options
+      ] =
+        traced_listen_options(transport, backend, [
+          [ip: {:local, unix_path}] ++ required_options,
+          [ifaddr: {:local, unix_path}] ++ required_options,
+          [ip: {:local, unix_path}, nodelay: false] ++ required_options,
+          [ifaddr: {:local, unix_path}, nodelay: false] ++ required_options,
+          required_options
+        ])
+
+      refute :proplists.is_defined(:nodelay, ip_unix_options)
+      refute :proplists.is_defined(:nodelay, ifaddr_unix_options)
+      assert :proplists.get_value(:nodelay, explicit_ip_options) == false
+      assert :proplists.get_value(:nodelay, explicit_ifaddr_options) == false
+      assert :proplists.get_value(:nodelay, ip_options) == true
+    end
+  end
+
+  defp transports do
+    [
+      {ThousandIsland.Transports.TCP, :gen_tcp, []},
+      {ThousandIsland.Transports.SSL, :ssl, [certfile: @certfile, keyfile: @keyfile]}
+    ]
+  end
+
+  defp traced_listen_options(transport, backend, options_list) do
+    Code.ensure_loaded!(backend)
+
+    task =
+      Task.async(fn ->
+        receive do
+          :listen ->
+            Enum.each(options_list, fn options ->
+              try do
+                case transport.listen(0, options) do
+                  {:ok, socket} -> transport.close(socket)
+                  {:error, _reason} -> :ok
+                end
+              rescue
+                ArgumentError -> :ok
+              end
+            end)
+        end
+      end)
+
+    :erlang.trace_pattern({backend, :listen, 2}, true, [])
+    :erlang.trace(task.pid, true, [:call])
+    send(task.pid, :listen)
+    task_pid = task.pid
+
+    try do
+      resolved_options =
+        Enum.map(options_list, fn _options ->
+          assert_receive {:trace, ^task_pid, :call, {^backend, :listen, [0, options]}},
+                         1_000
+
+          options
+        end)
+
+      Task.await(task)
+      resolved_options
+    after
+      :erlang.trace_pattern({backend, :listen, 2}, false, [])
+    end
+  end
+end


### PR DESCRIPTION
Note: I asked Claude to specifically look for spec non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

- Omit Thousand Island's default `nodelay: true` option when the configured listener address is a Unix domain socket, for both the `ip:` and `ifaddr:` forms of `{:local, path}`.
- Apply the change once in the shared `ThousandIsland.Transport.resolve_options/1` helper so TCP and SSL listeners behave identically.
- Document that `nodelay` is conditional and add a regression test that checks the exact options passed to OTP without requiring AF_UNIX support in the test environment.

## Non-conformance

**The rule.** OTP's [`gen_tcp` documentation](https://www.erlang.org/doc/apps/kernel/gen_tcp.html) states it directly: "The option nodelay is a TCP specific option that is not compatible with domain = local." On the backend difference it adds: "This does not actually work for inet_backend = inet either, but in that case the error is simply ignored, which is a bad idea. We have chosen to not ignore this error for inet_backend = socket." The [SSL transport accepts the same underlying listen options](https://www.erlang.org/doc/apps/ssl/ssl.html#type-socket_option). Meanwhile Thousand Island's own documentation supports `ip: {:local, path}` as a listener address, and OTP additionally accepts the `ifaddr: {:local, path}` form.

**What Thousand Island does today.** `ThousandIsland.Transport.resolve_options/1` appends the default `nodelay: true` to every listener's options, Unix domain listeners included, for both the TCP and SSL transports.

**What goes wrong.** Under the legacy inet backend the invalid combination is silently ignored, so it happens to work. Under `inet_backend: :socket`, whether selected per listener or node-wide, the incompatibility is enforced and the listener cannot start at all: on OTP 27.3.4 I observed the listen call fail fatally with a `badarg` exit (the documentation describes the rejection as `{:error, :enotsup}`; the observed shape differs, the substance does not). Thousand Island injects an option OTP declares invalid for an address type Thousand Island declares supported, and the cost is a listener that cannot start on the modern backend.

**What this PR makes it do.** The `nodelay: true` default is omitted when the listener address (via `ip:` or `ifaddr:`) is `{:local, path}`. An explicit `nodelay` value from the caller is passed through unchanged in all cases, and IP listeners keep the existing default.

## Test plan

Verified on Elixir 1.18.4 / Erlang OTP 27.3.4 against current `main`:

- `mix test test/thousand_island/transport_options_test.exs` passes.
- `mix test test/thousand_island/server_test.exs` passes.
- `mix format --check-formatted`, `mix credo --strict`, and `mix dialyzer` pass.
- The new test fails on unpatched `main` and passes with this change.

The new test traces the public transport calls into OTP and asserts that both TCP and SSL omit `nodelay` for the `ip` and `ifaddr` forms of `{:local, path}`, preserve an explicit `nodelay` value, and retain `nodelay: true` for IP listeners. This remains deterministic on hosts where Unix domain sockets cannot be opened. The test uses process-scoped call tracing, runs synchronously, and removes its trace pattern after each transport so other tests are unaffected.

## Compatibility / risks

- IP listeners retain the existing `nodelay: true` default.
- Unix domain listeners no longer receive an inapplicable TCP option, which also unbreaks them under `inet_backend: :socket`.
- An explicitly supplied `nodelay` option is passed through unchanged.